### PR TITLE
Subgraph layout: cluster-width feedback, per-level tightening, inter-cluster compaction, node-safe edge routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - **`LayoutConfig` spacing is now honored**: `node_spacing` and `level_spacing` were silently ignored (gaps hardcoded); both now apply in the heap and CSR layout paths. `level_spacing` default changed 2 → 0 to keep existing output unchanged.
+- **Cluster-width feedback**: unaffiliated nodes are pushed clear of subgraph borders (label-widened or inherited from wider levels), and the canvas now covers label-widened borders instead of clipping them. A subgraph label's contribution to box width is capped at 40 chars (longer labels are truncated by the renderer). Applies to both layout paths.
 
 ## [0.9.1] - 2026-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Improved
 - **Tighter subgraph layouts**: a per-level tightening pass reclaims the horizontal slack left behind when sibling clusters are shifted apart, so children align under their parents again. Both layout paths.
+- **Inter-cluster compaction**: root clusters and loose nodes are pulled back together after overlap separation, removing the empty gulfs between boxes (up to −24% canvas width on the stress tiers). Both layout paths.
+- **Edges never cross node text**: dummy waypoints are realigned when compaction moves their endpoints and nudged out of node spans; an edge that must cross something crosses a subgraph border (rendered as a junction), never a node. Both layout paths.
 
 ## [0.9.1] - 2026-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - **`LayoutConfig` spacing is now honored**: `node_spacing` and `level_spacing` were silently ignored (gaps hardcoded); both now apply in the heap and CSR layout paths. `level_spacing` default changed 2 → 0 to keep existing output unchanged.
 - **Cluster-width feedback**: unaffiliated nodes are pushed clear of subgraph borders (label-widened or inherited from wider levels), and the canvas now covers label-widened borders instead of clipping them. A subgraph label's contribution to box width is capped at 40 chars (longer labels are truncated by the renderer). Applies to both layout paths.
 
+### Improved
+- **Tighter subgraph layouts**: a per-level tightening pass reclaims the horizontal slack left behind when sibling clusters are shifted apart, so children align under their parents again. Both layout paths.
+
 ## [0.9.1] - 2026-03-25
 
 ### Improved

--- a/src/algorithms/sugiyama/arena_csr.rs
+++ b/src/algorithms/sugiyama/arena_csr.rs
@@ -75,6 +75,17 @@ pub(crate) struct LayoutTemps<'a> {
 // ── Subgraph layout constants ────────────────────────────────────────────
 /// Per-subgraph horizontal padding (chars on each side of border).
 const SUBGRAPH_H_PAD: usize = 2;
+/// Cap on how far a subgraph *label* may widen its bounding box.
+/// Twin of `subgraph::SUBGRAPH_LABEL_BOX_CAP`; renderers truncate longer
+/// labels to the box width, and the cap keeps a pathological heading from
+/// blowing up the canvas (and with it the render buffer).
+const SUBGRAPH_LABEL_BOX_CAP: usize = 40;
+
+/// Minimum box width needed to show `label` (borders + spaces), capped.
+#[inline]
+fn sg_label_min_width(label: &str) -> usize {
+    (label.len() + 4).min(SUBGRAPH_LABEL_BOX_CAP)
+}
 /// Vertical padding above first node: border + label + blank.
 const SUBGRAPH_V_PAD_TOP: usize = 3;
 /// Vertical padding below last node: blank + border.
@@ -302,6 +313,21 @@ pub fn compute_layout_arena_csr<'b>(
             temps.node_slots,
         );
         max_width = max_width.saturating_add(extra as Coord);
+
+        // Step 6c: Cluster-width feedback — push unaffiliated nodes clear
+        // of each cluster's projected border envelope (cross-level extent
+        // + label minimum). Runs after overlap repair so it sees the
+        // coordinates the bounding boxes will actually be computed from.
+        let pushed = clear_external_overlaps_csr(
+            graph,
+            temps.real_coords,
+            max_level as usize,
+            node_spacing_usize,
+            temps.sg_envelopes,
+            temps.sg_depths,
+            temps.positions,
+        );
+        max_width = max_width.saturating_add(pushed as Coord);
     }
 
     // Step 7: Build dummy positions using actual virtual level positions
@@ -519,7 +545,8 @@ pub fn compute_layout_arena_csr<'b>(
 
     // Add buffer for edge routing (+4) plus label margin
     let label_margin = if has_labeled_edges { 8 } else { 0 };
-    builder.set_dimensions(max_width as usize + 4 + label_margin, total_height);
+    let canvas_width = max_width as usize + 4 + label_margin;
+    builder.set_dimensions(canvas_width, total_height);
     builder.set_level_count(max_level as usize + 1);
 
     // Add nodes
@@ -793,7 +820,7 @@ pub fn compute_layout_arena_csr<'b>(
 
     // Step 10: Compute subgraph bounding boxes and add to builder
     if graph.has_subgraphs() {
-        compute_sg_bounding_boxes(
+        let sg_max_right = compute_sg_bounding_boxes(
             graph,
             temps.real_coords,
             temps.level_y_offsets,
@@ -803,6 +830,11 @@ pub fn compute_layout_arena_csr<'b>(
             temps.level_routing_floor,
             &mut builder,
         );
+        // The canvas must cover every border: a label-widened cluster box
+        // can extend past the node extent `canvas_width` was derived from.
+        if sg_max_right + 1 > canvas_width {
+            builder.set_dimensions(sg_max_right + 1, total_height);
+        }
     }
 
     Ok(builder.build())
@@ -1386,6 +1418,265 @@ fn gap_between_csr(
     }
 }
 
+/// Push unaffiliated nodes clear of subgraph bounding-box envelopes
+/// (cluster-width feedback). CSR twin of `subgraph::clear_external_overlaps`.
+///
+/// `subgraph_padding_csr` reserves space per level, but the border later
+/// drawn from `compute_sg_bounding_boxes` is a *global* x-envelope: the
+/// member extent across all levels, padded, widened to fit the label,
+/// and expanded around children. This pass projects that envelope with
+/// the same math and pushes overlapping external nodes right of it,
+/// iterating (bounded rounds).
+///
+/// It runs on `real_coords` **after** `fix_subgraph_overlaps_csr` so it
+/// sees the same coordinates the bounding boxes are computed from.
+/// Only **unaffiliated real nodes** are pushed: members of other clusters
+/// are left to the sibling-overlap repair (which moves whole clusters —
+/// pushing them individually would stretch their envelope and cascade),
+/// and dummies are never pushed (edges crossing a border render with
+/// junction glyphs).
+///
+/// `sg_envelopes` and `sg_depths` are borrowed as scratch (both are
+/// recomputed from scratch by their later users); `order_scratch` needs
+/// room for the largest level's real-node count.
+///
+/// Returns the growth of the maximum node right edge (0 if nothing moved).
+fn clear_external_overlaps_csr(
+    graph: &CsrGraph<'_>,
+    real_coords: &mut [(usize, usize, usize, usize)], // (level, pos, x, width)
+    max_level: usize,
+    node_spacing: usize,
+    sg_envelopes: &mut [(usize, usize, usize, usize)],
+    sg_depths: &mut [usize],
+    order_scratch: &mut [Idx],
+) -> usize {
+    let sg_count = graph.subgraph_count();
+    if sg_count == 0 || sg_count > sg_envelopes.len() || sg_count > sg_depths.len() {
+        return 0;
+    }
+    let node_count = graph.node_count().min(real_coords.len());
+    if node_count == 0 {
+        return 0;
+    }
+
+    const ENVELOPE_CLEARANCE: usize = 1;
+    // CSR levels are capped at 256 (`max_levels = node_count.min(256)`).
+    const MAX_LEVEL_SLOTS: usize = 257;
+    if max_level >= MAX_LEVEL_SLOTS {
+        return 0;
+    }
+    const SG_GAP: usize = 5;
+
+    for i in 0..sg_count {
+        sg_depths[i] = graph.sg_chain_depth(Some(i));
+    }
+    let max_depth = sg_depths[..sg_count].iter().copied().max().unwrap_or(0);
+
+    let before_max_right = real_coords[..node_count]
+        .iter()
+        .map(|c| c.2 + c.3)
+        .max()
+        .unwrap_or(0);
+
+    for _round in 0..8 {
+        // ── Project per-cluster x-envelopes + level ranges ──
+        // Scratch layout per subgraph: (left, right, first_level, last_level).
+        for e in sg_envelopes[..sg_count].iter_mut() {
+            *e = (usize::MAX, 0, usize::MAX, 0);
+        }
+
+        for node_idx in 0..node_count {
+            let Some(si) = graph.node_subgraph(node_idx) else {
+                continue;
+            };
+            if si >= sg_count {
+                continue;
+            }
+            let (level, _, x, w) = real_coords[node_idx];
+            let r = x + w;
+            let e = &mut sg_envelopes[si];
+            if x < e.0 {
+                e.0 = x;
+            }
+            if r > e.1 {
+                e.1 = r;
+            }
+            // Level range covers self and all ancestors.
+            let mut cur = Some(si);
+            while let Some(i) = cur {
+                if i < sg_count {
+                    let e = &mut sg_envelopes[i];
+                    if level < e.2 {
+                        e.2 = level;
+                    }
+                    if level > e.3 {
+                        e.3 = level;
+                    }
+                }
+                cur = graph.subgraph_parent(i);
+            }
+        }
+
+        // Pad + label minimum (mirrors compute_sg_bounding_boxes pass 1.5).
+        for si in 0..sg_count {
+            let (l, r, _, _) = sg_envelopes[si];
+            if l == usize::MAX {
+                continue;
+            }
+            let left = l.saturating_sub(SUBGRAPH_H_PAD);
+            let mut right = r + SUBGRAPH_H_PAD;
+            let min_label_width = sg_label_min_width(graph.subgraph_label(si));
+            if right - left < min_label_width {
+                right = left + min_label_width;
+            }
+            sg_envelopes[si].0 = left;
+            sg_envelopes[si].1 = right;
+        }
+
+        // Child → parent expansion deepest-first (mirrors pass 2).
+        let mut depth = max_depth;
+        loop {
+            for si in 0..sg_count {
+                if sg_depths[si] != depth {
+                    continue;
+                }
+                let (cl, cr, _, _) = sg_envelopes[si];
+                if cl == usize::MAX {
+                    continue;
+                }
+                if let Some(pi) = graph.subgraph_parent(si) {
+                    if pi >= sg_count {
+                        continue;
+                    }
+                    let exp_l = cl.saturating_sub(SUBGRAPH_H_PAD);
+                    let exp_r = cr + SUBGRAPH_H_PAD;
+                    let p = &mut sg_envelopes[pi];
+                    if p.0 == usize::MAX {
+                        p.0 = exp_l;
+                        p.1 = exp_r;
+                    } else {
+                        if exp_l < p.0 {
+                            p.0 = exp_l;
+                        }
+                        if exp_r > p.1 {
+                            p.1 = exp_r;
+                        }
+                    }
+                }
+            }
+            if depth == 0 {
+                break;
+            }
+            depth -= 1;
+        }
+        for si in 0..sg_count {
+            let (l, r, _, _) = sg_envelopes[si];
+            if l == usize::MAX {
+                continue;
+            }
+            let min_label_width = sg_label_min_width(graph.subgraph_label(si));
+            if r - l < min_label_width {
+                sg_envelopes[si].1 = l + min_label_width;
+            }
+        }
+
+        // ── Push overlapping unaffiliated nodes right of each envelope ──
+        let mut moved = false;
+        let mut touched = [false; MAX_LEVEL_SLOTS];
+        for si in 0..sg_count {
+            let (left, right, first, last) = sg_envelopes[si];
+            if left == usize::MAX || first == usize::MAX {
+                continue;
+            }
+            let mut cursors = [0usize; MAX_LEVEL_SLOTS];
+            for c in cursors[first..=last.min(max_level)].iter_mut() {
+                *c = right + ENVELOPE_CLEARANCE;
+            }
+            for node_idx in 0..node_count {
+                if graph.node_subgraph(node_idx).is_some() {
+                    continue;
+                }
+                let (level, _, x, w) = real_coords[node_idx];
+                if level < first || level > last || level >= MAX_LEVEL_SLOTS {
+                    continue;
+                }
+                if x < right && x + w > left {
+                    real_coords[node_idx].2 = cursors[level];
+                    cursors[level] += w + node_spacing;
+                    moved = true;
+                    touched[level] = true;
+                }
+            }
+        }
+        if !moved {
+            break;
+        }
+
+        // ── Re-establish min gaps on touched levels (push-right, x order) ──
+        // The insertion sort is quadratic in level size, so bound the level
+        // width it may run on; realistic subgraph levels are far smaller.
+        const GAP_SWEEP_MAX_LEVEL_SIZE: usize = 1024;
+        for level in 0..=max_level {
+            if !touched[level] {
+                continue;
+            }
+            // Collect this level's real nodes into the scratch.
+            let mut n = 0usize;
+            for node_idx in 0..node_count {
+                if real_coords[node_idx].0 == level {
+                    if n >= order_scratch.len() {
+                        n = usize::MAX;
+                        break;
+                    }
+                    order_scratch[n] = node_idx as Idx;
+                    n += 1;
+                }
+            }
+            if !(2..=GAP_SWEEP_MAX_LEVEL_SIZE).contains(&n) {
+                continue;
+            }
+            // Insertion sort by current x (stable).
+            for k in 1..n {
+                let mut j = k;
+                while j > 0 {
+                    let a = order_scratch[j - 1] as usize;
+                    let b = order_scratch[j] as usize;
+                    if (real_coords[a].2, order_scratch[j - 1])
+                        > (real_coords[b].2, order_scratch[j])
+                    {
+                        order_scratch.swap(j - 1, j);
+                        j -= 1;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            for k in 1..n {
+                let prev = order_scratch[k - 1] as usize;
+                let cur = order_scratch[k] as usize;
+                let prev_sg = graph.node_subgraph(prev);
+                let cur_sg = graph.node_subgraph(cur);
+                let gap = if prev_sg != cur_sg && (prev_sg.is_some() || cur_sg.is_some()) {
+                    SG_GAP
+                } else {
+                    node_spacing
+                };
+                let min_x = real_coords[prev].2 + real_coords[prev].3 + gap;
+                if real_coords[cur].2 < min_x {
+                    real_coords[cur].2 = min_x;
+                }
+            }
+        }
+    }
+
+    let after_max_right = real_coords[..node_count]
+        .iter()
+        .map(|c| c.2 + c.3)
+        .max()
+        .unwrap_or(0);
+    after_max_right.saturating_sub(before_max_right)
+}
+
 /// Left margin for a level (H_PAD if first node is in a subgraph).
 fn left_margin_csr(
     graph: &CsrGraph<'_>,
@@ -1886,7 +2177,7 @@ fn fix_subgraph_overlaps_csr(
             }
             let left = mn.saturating_sub(SUBGRAPH_H_PAD);
             let mut right = mx + SUBGRAPH_H_PAD;
-            let label_w = graph.subgraph_label(sg_idx).len() + 4;
+            let label_w = sg_label_min_width(graph.subgraph_label(sg_idx));
             if right.saturating_sub(left) < label_w {
                 right = left + label_w;
             }
@@ -2215,6 +2506,8 @@ fn compute_sg_y_extras(
 /// Uses sg_envelopes as scratch space.
 /// `level_routing_floor` contains the max Y used by edge routing at each level,
 /// so bottom borders can be placed below the routing area.
+/// Returns the maximum bounding-box right edge (`x + width`) across all
+/// subgraphs, so the caller can widen the canvas to cover every border.
 fn compute_sg_bounding_boxes(
     graph: &CsrGraph<'_>,
     real_coords: &[(usize, usize, usize, usize)], // (level, pos, x, width)
@@ -2224,10 +2517,10 @@ fn compute_sg_bounding_boxes(
     sg_envelopes: &mut [(usize, usize, usize, usize)],
     level_routing_floor: &[usize],
     builder: &mut LayoutIRArenaBuilder<'_>,
-) {
+) -> usize {
     let sg_count = graph.subgraph_count();
     if sg_count == 0 {
-        return;
+        return 0;
     }
 
     // Pass 1: compute node envelope per subgraph
@@ -2298,7 +2591,7 @@ fn compute_sg_bounding_boxes(
 
         // Ensure width fits label
         let label = graph.subgraph_label(sg_idx);
-        let min_label_width = label.len() + 4;
+        let min_label_width = sg_label_min_width(label);
         let width = right.saturating_sub(x);
         let right = if width < min_label_width {
             x + min_label_width
@@ -2403,6 +2696,7 @@ fn compute_sg_bounding_boxes(
     }
 
     // Add subgraph bounding boxes to builder
+    let mut max_right = 0usize;
     for sg_idx in 0..effective_sg {
         let (x, y, right, bottom) = sg_envelopes[sg_idx];
         if x == usize::MAX {
@@ -2414,7 +2708,9 @@ fn compute_sg_bounding_boxes(
         let parent_id = graph.subgraph_parent(sg_idx).map(|p| graph.subgraph_id(p));
         let label = graph.subgraph_label(sg_idx);
         builder.add_subgraph(sg_id, parent_id, label, x, y, width, height);
+        max_right = max_right.max(x + width);
     }
+    max_right
 }
 
 fn calculate_levels_csr(graph: &CsrGraph<'_>, levels: &mut [Idx], back_edges: &[bool]) -> Idx {
@@ -3899,5 +4195,122 @@ mod tests {
         // No trailing gap after the last level: total height grows by
         // exactly (levels - 1) * level_spacing.
         assert_eq!(spaced.height(), base.height() + 4);
+    }
+
+    // ── Cluster-width feedback (regression: external nodes rendered
+    //    inside subgraph borders) ────────────────────────────────────────
+
+    /// Build a one-subgraph graph, lay it out, and assert the nodes with
+    /// the given ids stay clear of every subgraph box.
+    fn assert_externals_clear_csr(
+        sg_label: &str,
+        nodes: &[(&str, bool)],
+        edges: &[(usize, usize)],
+        external_ids: &[usize],
+    ) {
+        let mut graph_buf = [0u8; 16384];
+        let mut graph_arena = Arena::new(&mut graph_buf);
+        let mut b =
+            CsrGraphBuilder::new_with_subgraphs(&mut graph_arena, 16, 16, 256, 4).expect("builder");
+        let sg = b.add_subgraph(0, sg_label).expect("sg");
+        for (i, (label, _)) in nodes.iter().enumerate() {
+            b.add_node(i, label).expect("node");
+        }
+        for (i, (_, inside)) in nodes.iter().enumerate() {
+            if *inside {
+                b.set_node_subgraph(i, sg).expect("assign");
+            }
+        }
+        for &(f, t) in edges {
+            b.add_edge(f, t).expect("edge");
+        }
+        let graph = b.build().expect("build");
+
+        let config = LayoutConfig::standard();
+        let mut temp_buf = [0u8; 65536];
+        let mut temp_arena = Arena::new(&mut temp_buf);
+        let mut out_buf = [0u8; 65536];
+        let mut out_arena = Arena::new(&mut out_buf);
+        let ir = compute_layout_arena_csr(&graph, &config, &mut temp_arena, &mut out_arena)
+            .expect("layout");
+
+        for sg in ir.subgraphs() {
+            assert!(
+                sg.x + sg.width <= ir.width(),
+                "canvas clips subgraph border (right {} > width {})",
+                sg.x + sg.width,
+                ir.width(),
+            );
+            for n in ir.nodes().iter().filter(|n| external_ids.contains(&n.id)) {
+                let x_overlap = n.x < sg.x + sg.width && n.x + n.width > sg.x;
+                let y_overlap = n.y >= sg.y && n.y < sg.y + sg.height;
+                assert!(
+                    !(x_overlap && y_overlap),
+                    "external node id={} overlaps subgraph box",
+                    n.id,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_book_length_label_capped_csr() {
+        let long_label = "L".repeat(300);
+        let mut graph_buf = [0u8; 16384];
+        let mut graph_arena = Arena::new(&mut graph_buf);
+        let mut b =
+            CsrGraphBuilder::new_with_subgraphs(&mut graph_arena, 4, 4, 512, 2).expect("builder");
+        let sg = b.add_subgraph(0, &long_label).expect("sg");
+        b.add_node(0, "A").expect("node");
+        b.add_node(1, "B").expect("node");
+        b.set_node_subgraph(0, sg).expect("assign");
+        b.set_node_subgraph(1, sg).expect("assign");
+        b.add_edge(0, 1).expect("edge");
+        let graph = b.build().expect("build");
+
+        let config = LayoutConfig::standard();
+        let mut temp_buf = [0u8; 65536];
+        let mut temp_arena = Arena::new(&mut temp_buf);
+        let mut out_buf = [0u8; 65536];
+        let mut out_arena = Arena::new(&mut out_buf);
+        let ir = compute_layout_arena_csr(&graph, &config, &mut temp_arena, &mut out_arena)
+            .expect("layout");
+
+        let info = &ir.subgraphs()[0];
+        assert!(
+            info.width <= 40,
+            "label must not widen the box past the cap (got {})",
+            info.width,
+        );
+        assert!(
+            ir.width() < 100,
+            "canvas must not scale with label length (got {})",
+            ir.width(),
+        );
+    }
+
+    #[test]
+    fn test_label_widened_subgraph_clear_of_externals_csr() {
+        assert_externals_clear_csr(
+            "VeryLongSubgraphLabelHere",
+            &[("X", true), ("E", false), ("X2", true), ("E2", false)],
+            &[(0, 2), (1, 3)],
+            &[1, 3],
+        );
+    }
+
+    #[test]
+    fn test_cross_level_envelope_clear_of_externals_csr() {
+        assert_externals_clear_csr(
+            "C",
+            &[
+                ("WideMemberNodeAAA", true),
+                ("WideMemberNodeBBB", true),
+                ("m", true),
+                ("ext", false),
+            ],
+            &[(0, 2), (1, 2), (0, 3)],
+            &[3],
+        );
     }
 }

--- a/src/algorithms/sugiyama/arena_csr.rs
+++ b/src/algorithms/sugiyama/arena_csr.rs
@@ -314,6 +314,16 @@ pub fn compute_layout_arena_csr<'b>(
         );
         max_width = max_width.saturating_add(extra as Coord);
 
+        // Reclaim slack the sibling shifts left behind: pull nodes toward
+        // their connected neighbors within current level bounds.
+        tighten_levels_csr(
+            graph,
+            temps.real_coords,
+            max_level as usize,
+            node_spacing_usize,
+            temps.positions,
+        );
+
         // Step 6c: Cluster-width feedback — push unaffiliated nodes clear
         // of each cluster's projected border envelope (cross-level extent
         // + label minimum). Runs after overlap repair so it sees the
@@ -1415,6 +1425,165 @@ fn gap_between_csr(
         SG_GAP
     } else {
         node_spacing
+    }
+}
+
+/// Reclaim horizontal slack on each level (post-shift tightening).
+/// CSR twin of `subgraph::tighten_levels`.
+///
+/// Sweeps each level in x order and moves every real node toward the
+/// median center of its connected neighbors, strictly bounded by its
+/// current level neighbors — so it can never widen a level, and the
+/// rightmost node may only move left. `order_scratch` holds the x-order
+/// permutation for one level (the `positions` crossing scratch fits).
+fn tighten_levels_csr(
+    graph: &CsrGraph<'_>,
+    real_coords: &mut [(usize, usize, usize, usize)], // (level, pos, x, width)
+    max_level: usize,
+    node_spacing: usize,
+    order_scratch: &mut [Idx],
+) {
+    let node_count = graph.node_count().min(real_coords.len());
+    if node_count < 2 {
+        return;
+    }
+    const SG_GAP: usize = 5;
+    // Bound the per-level insertion sort (quadratic in level size).
+    const TIGHTEN_MAX_LEVEL_SIZE: usize = 1024;
+    // Per-cluster extent snapshot lives on the stack; skip the pass for
+    // graphs with more clusters than the snapshot holds (tightening is
+    // cosmetic — skipping is always safe).
+    const TIGHTEN_MAX_SUBGRAPHS: usize = 128;
+
+    let sg_count = graph.subgraph_count();
+    if sg_count > TIGHTEN_MAX_SUBGRAPHS {
+        return;
+    }
+
+    for _sweep in 0..4 {
+        let mut moved = false;
+
+        // Snapshot each immediate cluster's member extent (min x, max right)
+        // across all levels. Members may only move within it, so no cluster
+        // bounding box can grow — growth would re-overlap sibling boxes that
+        // fix_subgraph_overlaps_csr just separated.
+        let mut extents = [(usize::MAX, 0usize); TIGHTEN_MAX_SUBGRAPHS];
+        for ni in 0..node_count {
+            if let Some(sg) = graph.node_subgraph(ni) {
+                if sg < TIGHTEN_MAX_SUBGRAPHS {
+                    let (_, _, x, w) = real_coords[ni];
+                    extents[sg].0 = extents[sg].0.min(x);
+                    extents[sg].1 = extents[sg].1.max(x + w);
+                }
+            }
+        }
+        for level in 0..=max_level {
+            // Collect this level's real nodes into the scratch.
+            let mut n = 0usize;
+            for node_idx in 0..node_count {
+                if real_coords[node_idx].0 == level {
+                    if n >= order_scratch.len() || n >= TIGHTEN_MAX_LEVEL_SIZE {
+                        n = usize::MAX;
+                        break;
+                    }
+                    order_scratch[n] = node_idx as Idx;
+                    n += 1;
+                }
+            }
+            if n == usize::MAX || n == 0 {
+                continue;
+            }
+            // Insertion sort by current x (stable).
+            for k in 1..n {
+                let mut j = k;
+                while j > 0 {
+                    let a = order_scratch[j - 1] as usize;
+                    let b = order_scratch[j] as usize;
+                    if (real_coords[a].2, order_scratch[j - 1])
+                        > (real_coords[b].2, order_scratch[j])
+                    {
+                        order_scratch.swap(j - 1, j);
+                        j -= 1;
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            for k in 0..n {
+                let ni = order_scratch[k] as usize;
+                let (_, _, x, w) = real_coords[ni];
+
+                // Median center of connected neighbors (parents + children).
+                let mut centers = [0usize; 32];
+                let mut count = 0usize;
+                for &c in graph.children(ni) {
+                    let c = c as usize;
+                    if c < node_count && count < 32 {
+                        centers[count] = real_coords[c].2 + real_coords[c].3 / 2;
+                        count += 1;
+                    }
+                }
+                for &pa in graph.parents(ni) {
+                    let pa = pa as usize;
+                    if pa < node_count && count < 32 {
+                        centers[count] = real_coords[pa].2 + real_coords[pa].3 / 2;
+                        count += 1;
+                    }
+                }
+                if count == 0 {
+                    continue;
+                }
+                centers[..count].sort_unstable();
+                let target_center = centers[count / 2];
+                let desired = target_center.saturating_sub(w / 2);
+
+                let my_sg = graph.node_subgraph(ni);
+                let mut min_x = if k == 0 {
+                    if my_sg.is_some() { SUBGRAPH_H_PAD } else { 0 }
+                } else {
+                    let prev = order_scratch[k - 1] as usize;
+                    let prev_sg = graph.node_subgraph(prev);
+                    let gap = if prev_sg != my_sg && (prev_sg.is_some() || my_sg.is_some()) {
+                        SG_GAP
+                    } else {
+                        node_spacing
+                    };
+                    real_coords[prev].2 + real_coords[prev].3 + gap
+                };
+                let mut max_x = if k + 1 < n {
+                    let next = order_scratch[k + 1] as usize;
+                    let next_sg = graph.node_subgraph(next);
+                    let gap = if next_sg != my_sg && (next_sg.is_some() || my_sg.is_some()) {
+                        SG_GAP
+                    } else {
+                        node_spacing
+                    };
+                    real_coords[next].2.saturating_sub(gap + w)
+                } else {
+                    // Rightmost node: never move right (keeps canvas bounded).
+                    x
+                };
+                if let Some(sg) = my_sg {
+                    if sg < TIGHTEN_MAX_SUBGRAPHS {
+                        let (ext_lo, ext_hi) = extents[sg];
+                        min_x = min_x.max(ext_lo);
+                        max_x = max_x.min(ext_hi.saturating_sub(w));
+                    }
+                }
+                if max_x < min_x {
+                    continue;
+                }
+                let new_x = desired.clamp(min_x, max_x);
+                if new_x != x {
+                    real_coords[ni].2 = new_x;
+                    moved = true;
+                }
+            }
+        }
+        if !moved {
+            break;
+        }
     }
 }
 

--- a/src/algorithms/sugiyama/arena_csr.rs
+++ b/src/algorithms/sugiyama/arena_csr.rs
@@ -338,6 +338,33 @@ pub fn compute_layout_arena_csr<'b>(
             temps.positions,
         );
         max_width = max_width.saturating_add(pushed as Coord);
+
+        // Pull whole root clusters (and loose nodes) back together after
+        // the overlap shifts — reclaims the empty gulfs between boxes.
+        let reclaimed = compact_clusters_csr(
+            graph,
+            temps.real_coords,
+            max_level as usize,
+            node_spacing_usize,
+            temps.sg_envelopes,
+            temps.sg_depths,
+            temps.vlevel_offsets,
+            temps.vnode_data,
+            temps.x_coords,
+            temps.node_levels,
+        );
+        max_width = max_width.saturating_sub(reclaimed as Coord);
+
+        // Waypoints must never cross node text (crossing a border renders
+        // as a junction and is acceptable; crossing a node is not).
+        nudge_dummies_off_nodes_csr(
+            graph,
+            temps.real_coords,
+            temps.vlevel_offsets,
+            temps.vnode_data,
+            temps.x_coords,
+            max_level as usize,
+        );
     }
 
     // Step 7: Build dummy positions using actual virtual level positions
@@ -1587,6 +1614,423 @@ fn tighten_levels_csr(
     }
 }
 
+/// Project per-cluster x-envelopes and level ranges into `sg_envelopes`
+/// (scratch layout per subgraph: left, right, first_level, last_level),
+/// mirroring `compute_sg_bounding_boxes` x-math: member extent,
+/// `SUBGRAPH_H_PAD`, label minimum width, child → parent expansion
+/// (deepest-first via `sg_depths`), label recheck.
+fn project_sg_envelopes_csr(
+    graph: &CsrGraph<'_>,
+    real_coords: &[(usize, usize, usize, usize)],
+    node_count: usize,
+    sg_count: usize,
+    max_depth: usize,
+    sg_envelopes: &mut [(usize, usize, usize, usize)],
+    sg_depths: &[usize],
+) {
+    for e in sg_envelopes[..sg_count].iter_mut() {
+        *e = (usize::MAX, 0, usize::MAX, 0);
+    }
+
+    for node_idx in 0..node_count {
+        let Some(si) = graph.node_subgraph(node_idx) else {
+            continue;
+        };
+        if si >= sg_count {
+            continue;
+        }
+        let (level, _, x, w) = real_coords[node_idx];
+        let r = x + w;
+        let e = &mut sg_envelopes[si];
+        if x < e.0 {
+            e.0 = x;
+        }
+        if r > e.1 {
+            e.1 = r;
+        }
+        // Level range covers self and all ancestors.
+        let mut cur = Some(si);
+        while let Some(i) = cur {
+            if i < sg_count {
+                let e = &mut sg_envelopes[i];
+                if level < e.2 {
+                    e.2 = level;
+                }
+                if level > e.3 {
+                    e.3 = level;
+                }
+            }
+            cur = graph.subgraph_parent(i);
+        }
+    }
+
+    // Pad + label minimum (mirrors compute_sg_bounding_boxes pass 1.5).
+    for si in 0..sg_count {
+        let (l, r, _, _) = sg_envelopes[si];
+        if l == usize::MAX {
+            continue;
+        }
+        let left = l.saturating_sub(SUBGRAPH_H_PAD);
+        let mut right = r + SUBGRAPH_H_PAD;
+        let min_label_width = sg_label_min_width(graph.subgraph_label(si));
+        if right - left < min_label_width {
+            right = left + min_label_width;
+        }
+        sg_envelopes[si].0 = left;
+        sg_envelopes[si].1 = right;
+    }
+
+    // Child → parent expansion deepest-first (mirrors pass 2).
+    let mut depth = max_depth;
+    loop {
+        for si in 0..sg_count {
+            if sg_depths[si] != depth {
+                continue;
+            }
+            let (cl, cr, _, _) = sg_envelopes[si];
+            if cl == usize::MAX {
+                continue;
+            }
+            if let Some(pi) = graph.subgraph_parent(si) {
+                if pi >= sg_count {
+                    continue;
+                }
+                let exp_l = cl.saturating_sub(SUBGRAPH_H_PAD);
+                let exp_r = cr + SUBGRAPH_H_PAD;
+                let p = &mut sg_envelopes[pi];
+                if p.0 == usize::MAX {
+                    p.0 = exp_l;
+                    p.1 = exp_r;
+                } else {
+                    if exp_l < p.0 {
+                        p.0 = exp_l;
+                    }
+                    if exp_r > p.1 {
+                        p.1 = exp_r;
+                    }
+                }
+            }
+        }
+        if depth == 0 {
+            break;
+        }
+        depth -= 1;
+    }
+    for si in 0..sg_count {
+        let (l, r, _, _) = sg_envelopes[si];
+        if l == usize::MAX {
+            continue;
+        }
+        let min_label_width = sg_label_min_width(graph.subgraph_label(si));
+        if r - l < min_label_width {
+            sg_envelopes[si].1 = l + min_label_width;
+        }
+    }
+}
+
+/// Compact root clusters and unaffiliated nodes leftward.
+/// CSR twin of `subgraph::compact_clusters`.
+///
+/// Treats each root cluster as a rigid body and each unaffiliated node
+/// as a singleton body, sweeps bodies left-to-right, and shifts each as
+/// far left as the per-level frontier allows (envelope↔envelope keeps
+/// `SIBLING_GAP_CSR`, envelope↔node 1, node↔node `node_spacing`).
+/// Shift-left only. Body count is capped by a fixed stack table; larger
+/// graphs skip the pass (it is cosmetic, so skipping is always safe).
+///
+/// Returns the reclaimed canvas width (conservative minimum of node- and
+/// envelope-extent reductions).
+#[allow(clippy::too_many_arguments)]
+fn compact_clusters_csr(
+    graph: &CsrGraph<'_>,
+    real_coords: &mut [(usize, usize, usize, usize)],
+    max_level: usize,
+    node_spacing: usize,
+    sg_envelopes: &mut [(usize, usize, usize, usize)],
+    sg_depths: &mut [usize],
+    vlevel_offsets: &[Idx],
+    vnode_data: &[Idx],
+    x_coords: &mut [Coord],
+    node_levels: &[Idx],
+) -> usize {
+    let sg_count = graph.subgraph_count();
+    if sg_count == 0 || sg_count > sg_envelopes.len() || sg_count > sg_depths.len() {
+        return 0;
+    }
+    let node_count = graph.node_count().min(real_coords.len());
+    if node_count == 0 {
+        return 0;
+    }
+
+    const ENVELOPE_CLEARANCE: usize = 1;
+    const SIBLING_GAP_CSR: usize = 1;
+    const MAX_LEVEL_SLOTS: usize = 257;
+    const MAX_BODIES: usize = 256;
+    if max_level >= MAX_LEVEL_SLOTS {
+        return 0;
+    }
+
+    for i in 0..sg_count {
+        sg_depths[i] = graph.sg_chain_depth(Some(i));
+    }
+    let max_depth = sg_depths[..sg_count].iter().copied().max().unwrap_or(0);
+
+    project_sg_envelopes_csr(
+        graph,
+        real_coords,
+        node_count,
+        sg_count,
+        max_depth,
+        sg_envelopes,
+        sg_depths,
+    );
+
+    let before_node_right = real_coords[..node_count]
+        .iter()
+        .map(|c| c.2 + c.3)
+        .max()
+        .unwrap_or(0);
+    let before_env_right = sg_envelopes[..sg_count]
+        .iter()
+        .filter(|e| e.0 != usize::MAX)
+        .map(|e| e.1)
+        .max()
+        .unwrap_or(0);
+
+    let root_of = |mut i: usize| -> usize {
+        while let Some(p) = graph.subgraph_parent(i) {
+            i = p;
+        }
+        i
+    };
+
+    // Bodies: (left, right, idx, is_cluster). Fixed stack table.
+    let mut bodies = [(0usize, 0usize, 0usize, false); MAX_BODIES];
+    let mut n_bodies = 0usize;
+    for si in 0..sg_count {
+        if graph.subgraph_parent(si).is_none() {
+            let (l, r, f, _) = sg_envelopes[si];
+            if l == usize::MAX || f == usize::MAX {
+                continue;
+            }
+            if n_bodies >= MAX_BODIES {
+                return 0;
+            }
+            bodies[n_bodies] = (l, r, si, true);
+            n_bodies += 1;
+        }
+    }
+    for node_idx in 0..node_count {
+        if graph.node_subgraph(node_idx).is_none() {
+            let (_, _, x, w) = real_coords[node_idx];
+            if n_bodies >= MAX_BODIES {
+                return 0;
+            }
+            bodies[n_bodies] = (x, x + w, node_idx, false);
+            n_bodies += 1;
+        }
+    }
+    // Insertion sort by (left, right, idx).
+    for k in 1..n_bodies {
+        let mut j = k;
+        while j > 0 && (bodies[j - 1].0, bodies[j - 1].1, bodies[j - 1].2)
+            > (bodies[j].0, bodies[j].1, bodies[j].2)
+        {
+            bodies.swap(j - 1, j);
+            j -= 1;
+        }
+    }
+
+    // Per-level frontiers (usize::MAX = none yet).
+    let mut env_right = [usize::MAX; MAX_LEVEL_SLOTS];
+    let mut node_right = [usize::MAX; MAX_LEVEL_SLOTS];
+    // Shift applied per body, for realigning dummy waypoints below.
+    let mut body_delta = [0usize; MAX_BODIES];
+
+    for (bi, &(env_left, env_r, idx, is_cluster)) in bodies[..n_bodies].iter().enumerate() {
+        if is_cluster {
+            let (_, _, first, last) = sg_envelopes[idx];
+            if first == usize::MAX {
+                continue;
+            }
+            let mut allowed = 0usize;
+            for lvl in first..=last.min(max_level) {
+                if env_right[lvl] != usize::MAX {
+                    allowed = allowed.max(env_right[lvl] + SIBLING_GAP_CSR);
+                }
+                if node_right[lvl] != usize::MAX {
+                    allowed = allowed.max(node_right[lvl] + ENVELOPE_CLEARANCE);
+                }
+            }
+            let delta = env_left.saturating_sub(allowed);
+            body_delta[bi] = delta;
+            if delta > 0 {
+                for node_idx in 0..node_count {
+                    if let Some(si) = graph.node_subgraph(node_idx) {
+                        if si < sg_count && root_of(si) == idx {
+                            real_coords[node_idx].2 -= delta;
+                        }
+                    }
+                }
+            }
+            let new_right = env_r - delta;
+            for lvl in first..=last.min(max_level) {
+                if env_right[lvl] == usize::MAX || env_right[lvl] < new_right {
+                    env_right[lvl] = new_right;
+                }
+            }
+        } else {
+            let (lvl, _, x, w) = real_coords[idx];
+            if lvl >= MAX_LEVEL_SLOTS {
+                continue;
+            }
+            let mut allowed = 0usize;
+            if env_right[lvl] != usize::MAX {
+                allowed = allowed.max(env_right[lvl] + ENVELOPE_CLEARANCE);
+            }
+            if node_right[lvl] != usize::MAX {
+                allowed = allowed.max(node_right[lvl] + node_spacing);
+            }
+            let delta = x.saturating_sub(allowed);
+            body_delta[bi] = delta;
+            if delta > 0 {
+                real_coords[idx].2 = x - delta;
+            }
+            let r = x - delta + w;
+            if node_right[lvl] == usize::MAX || node_right[lvl] < r {
+                node_right[lvl] = r;
+            }
+        }
+    }
+
+    // Realign dummy waypoints with the bodies that moved (see the heap
+    // twin in subgraph.rs): each dummy snaps to the nearer endpoint's
+    // shift, so the chain stays straight in two runs with at most one
+    // jog at the midpoint.
+    let delta_of_node = |ni: usize| -> usize {
+        if let Some(si) = graph.node_subgraph(ni) {
+            if si < sg_count {
+                let root = root_of(si);
+                for (bi, &(_, _, idx, is_cluster)) in bodies[..n_bodies].iter().enumerate() {
+                    if is_cluster && idx == root {
+                        return body_delta[bi];
+                    }
+                }
+            }
+            0
+        } else {
+            for (bi, &(_, _, idx, is_cluster)) in bodies[..n_bodies].iter().enumerate() {
+                if !is_cluster && idx == ni {
+                    return body_delta[bi];
+                }
+            }
+            0
+        }
+    };
+    let edge_count = graph.edge_count();
+    for level in 0..=max_level {
+        let start = vlevel_offsets[level] as usize;
+        let end = vlevel_offsets[level + 1] as usize;
+        for pos in start..end {
+            if vnode_data[pos * 2] != 1 {
+                continue;
+            }
+            let edge_idx = vnode_data[pos * 2 + 1] as usize;
+            if edge_idx >= edge_count {
+                continue;
+            }
+            let (f, t) = graph.edge(edge_idx);
+            if f >= node_count || t >= node_count {
+                continue;
+            }
+            let df = delta_of_node(f);
+            let dt = delta_of_node(t);
+            let lf = node_levels.get(f).map(|&l| l as i64).unwrap_or(0);
+            let lt = node_levels.get(t).map(|&l| l as i64).unwrap_or(0);
+            let delta = if (level as i64 - lf).abs() <= (lt - level as i64).abs() {
+                df
+            } else {
+                dt
+            };
+            if let Some(x) = x_coords.get_mut(pos) {
+                *x = x.saturating_sub(delta.min(Coord::MAX as usize) as Coord);
+            }
+        }
+    }
+
+    project_sg_envelopes_csr(
+        graph,
+        real_coords,
+        node_count,
+        sg_count,
+        max_depth,
+        sg_envelopes,
+        sg_depths,
+    );
+    let after_node_right = real_coords[..node_count]
+        .iter()
+        .map(|c| c.2 + c.3)
+        .max()
+        .unwrap_or(0);
+    let after_env_right = sg_envelopes[..sg_count]
+        .iter()
+        .filter(|e| e.0 != usize::MAX)
+        .map(|e| e.1)
+        .max()
+        .unwrap_or(0);
+    let node_reclaim = before_node_right.saturating_sub(after_node_right);
+    let env_reclaim = before_env_right.saturating_sub(after_env_right);
+    node_reclaim.min(env_reclaim)
+}
+
+/// Nudge dummy waypoints out of real node spans.
+/// CSR twin of `subgraph::nudge_dummies_off_nodes` — see it for the
+/// rationale (an edge may cross a subgraph border, never node text).
+fn nudge_dummies_off_nodes_csr(
+    graph: &CsrGraph<'_>,
+    real_coords: &[(usize, usize, usize, usize)],
+    vlevel_offsets: &[Idx],
+    vnode_data: &[Idx],
+    x_coords: &mut [Coord],
+    max_level: usize,
+) {
+    let node_count = graph.node_count().min(real_coords.len());
+    for level in 0..=max_level {
+        let start = vlevel_offsets[level] as usize;
+        let end = vlevel_offsets[level + 1] as usize;
+        for pos in start..end {
+            if vnode_data[pos * 2] != 1 {
+                continue;
+            }
+            let edge_idx = vnode_data[pos * 2 + 1] as usize;
+            // The renderer draws this edge's vertical at x + (edge_idx % 4).
+            let off = edge_idx % 4;
+            let Some(&x) = x_coords.get(pos) else {
+                continue;
+            };
+            let mut col = x as usize + off;
+            for _ in 0..8 {
+                let mut hit = None;
+                for node_idx in 0..node_count {
+                    let (nl, _, nx, nw) = real_coords[node_idx];
+                    if nl == level && col >= nx && col < nx + nw {
+                        hit = Some((nx, nx + nw));
+                        break;
+                    }
+                }
+                let Some((sl, sr)) = hit else {
+                    break;
+                };
+                let go_left = sl > off && (col - sl) < (sr - col);
+                col = if go_left { sl - 1 } else { sr };
+            }
+            if col != x as usize + off {
+                x_coords[pos] = ((col - off).min(Coord::MAX as usize)) as Coord;
+            }
+        }
+    }
+}
+
 /// Push unaffiliated nodes clear of subgraph bounding-box envelopes
 /// (cluster-width feedback). CSR twin of `subgraph::clear_external_overlaps`.
 ///
@@ -1648,106 +2092,7 @@ fn clear_external_overlaps_csr(
         .unwrap_or(0);
 
     for _round in 0..8 {
-        // ── Project per-cluster x-envelopes + level ranges ──
-        // Scratch layout per subgraph: (left, right, first_level, last_level).
-        for e in sg_envelopes[..sg_count].iter_mut() {
-            *e = (usize::MAX, 0, usize::MAX, 0);
-        }
-
-        for node_idx in 0..node_count {
-            let Some(si) = graph.node_subgraph(node_idx) else {
-                continue;
-            };
-            if si >= sg_count {
-                continue;
-            }
-            let (level, _, x, w) = real_coords[node_idx];
-            let r = x + w;
-            let e = &mut sg_envelopes[si];
-            if x < e.0 {
-                e.0 = x;
-            }
-            if r > e.1 {
-                e.1 = r;
-            }
-            // Level range covers self and all ancestors.
-            let mut cur = Some(si);
-            while let Some(i) = cur {
-                if i < sg_count {
-                    let e = &mut sg_envelopes[i];
-                    if level < e.2 {
-                        e.2 = level;
-                    }
-                    if level > e.3 {
-                        e.3 = level;
-                    }
-                }
-                cur = graph.subgraph_parent(i);
-            }
-        }
-
-        // Pad + label minimum (mirrors compute_sg_bounding_boxes pass 1.5).
-        for si in 0..sg_count {
-            let (l, r, _, _) = sg_envelopes[si];
-            if l == usize::MAX {
-                continue;
-            }
-            let left = l.saturating_sub(SUBGRAPH_H_PAD);
-            let mut right = r + SUBGRAPH_H_PAD;
-            let min_label_width = sg_label_min_width(graph.subgraph_label(si));
-            if right - left < min_label_width {
-                right = left + min_label_width;
-            }
-            sg_envelopes[si].0 = left;
-            sg_envelopes[si].1 = right;
-        }
-
-        // Child → parent expansion deepest-first (mirrors pass 2).
-        let mut depth = max_depth;
-        loop {
-            for si in 0..sg_count {
-                if sg_depths[si] != depth {
-                    continue;
-                }
-                let (cl, cr, _, _) = sg_envelopes[si];
-                if cl == usize::MAX {
-                    continue;
-                }
-                if let Some(pi) = graph.subgraph_parent(si) {
-                    if pi >= sg_count {
-                        continue;
-                    }
-                    let exp_l = cl.saturating_sub(SUBGRAPH_H_PAD);
-                    let exp_r = cr + SUBGRAPH_H_PAD;
-                    let p = &mut sg_envelopes[pi];
-                    if p.0 == usize::MAX {
-                        p.0 = exp_l;
-                        p.1 = exp_r;
-                    } else {
-                        if exp_l < p.0 {
-                            p.0 = exp_l;
-                        }
-                        if exp_r > p.1 {
-                            p.1 = exp_r;
-                        }
-                    }
-                }
-            }
-            if depth == 0 {
-                break;
-            }
-            depth -= 1;
-        }
-        for si in 0..sg_count {
-            let (l, r, _, _) = sg_envelopes[si];
-            if l == usize::MAX {
-                continue;
-            }
-            let min_label_width = sg_label_min_width(graph.subgraph_label(si));
-            if r - l < min_label_width {
-                sg_envelopes[si].1 = l + min_label_width;
-            }
-        }
+        project_sg_envelopes_csr(graph, real_coords, node_count, sg_count, max_depth, sg_envelopes, sg_depths);
 
         // ── Push overlapping unaffiliated nodes right of each envelope ──
         let mut moved = false;

--- a/src/algorithms/sugiyama/heap.rs
+++ b/src/algorithms/sugiyama/heap.rs
@@ -294,7 +294,24 @@ pub(crate) fn compute_layout_cfg<'a>(dag: &Graph<'a>, config: &LayoutConfig<'_>)
             &mut real_node_coords,
             node_spacing,
         );
-        max_width + extra + pushed
+        // Pull whole root clusters (and loose nodes) back together after
+        // the overlap shifts — reclaims the empty gulfs between boxes.
+        let reclaimed = crate::algorithms::sugiyama::subgraph::compact_clusters(
+            dag,
+            &mut real_node_coords,
+            &virtual_levels,
+            &mut x_coords,
+            &node_levels,
+            node_spacing,
+        );
+        // Waypoints must never cross node text (crossing a border renders
+        // as a junction and is acceptable; crossing a node is not).
+        crate::algorithms::sugiyama::subgraph::nudge_dummies_off_nodes(
+            &virtual_levels,
+            &mut x_coords,
+            &real_node_coords,
+        );
+        (max_width + extra + pushed).saturating_sub(reclaimed)
     } else {
         max_width
     };

--- a/src/algorithms/sugiyama/heap.rs
+++ b/src/algorithms/sugiyama/heap.rs
@@ -278,7 +278,16 @@ pub(crate) fn compute_layout_cfg<'a>(dag: &Graph<'a>, config: &LayoutConfig<'_>)
             dag,
             &mut real_node_coords,
         );
-        max_width + extra
+        // Cluster-width feedback: push unaffiliated nodes clear of each
+        // cluster's projected border envelope (cross-level extent + label
+        // minimum). Runs after overlap repair so it sees the coordinates
+        // the bounding boxes will actually be computed from.
+        let pushed = crate::algorithms::sugiyama::subgraph::clear_external_overlaps(
+            dag,
+            &mut real_node_coords,
+            node_spacing,
+        );
+        max_width + extra + pushed
     } else {
         max_width
     };
@@ -744,9 +753,10 @@ pub(crate) fn compute_layout_cfg<'a>(dag: &Graph<'a>, config: &LayoutConfig<'_>)
         }
     }
 
-    builder.set_dimensions(max_width, total_height);
-
-    // Compute subgraph bounding boxes if any subgraphs are defined
+    // Compute subgraph bounding boxes if any subgraphs are defined.
+    // The canvas must cover every border: a label-widened cluster box can
+    // extend past the node extent that `max_width` was derived from.
+    let mut canvas_width = max_width;
     if dag.has_subgraphs() {
         let sg_infos = crate::algorithms::sugiyama::subgraph::compute_bounding_boxes(
             dag,
@@ -757,9 +767,11 @@ pub(crate) fn compute_layout_cfg<'a>(dag: &Graph<'a>, config: &LayoutConfig<'_>)
             &level_routing_floor,
         );
         for info in sg_infos {
+            canvas_width = canvas_width.max(info.x + info.width + 1);
             builder.add_subgraph(info);
         }
     }
+    builder.set_dimensions(canvas_width, total_height);
 
     builder.build()
 }

--- a/src/algorithms/sugiyama/heap.rs
+++ b/src/algorithms/sugiyama/heap.rs
@@ -278,6 +278,13 @@ pub(crate) fn compute_layout_cfg<'a>(dag: &Graph<'a>, config: &LayoutConfig<'_>)
             dag,
             &mut real_node_coords,
         );
+        // Reclaim slack the sibling shifts left behind: pull nodes toward
+        // their connected neighbors within current level bounds.
+        crate::algorithms::sugiyama::subgraph::tighten_levels(
+            dag,
+            &mut real_node_coords,
+            node_spacing,
+        );
         // Cluster-width feedback: push unaffiliated nodes clear of each
         // cluster's projected border envelope (cross-level extent + label
         // minimum). Runs after overlap repair so it sees the coordinates

--- a/src/algorithms/sugiyama/subgraph.rs
+++ b/src/algorithms/sugiyama/subgraph.rs
@@ -446,58 +446,7 @@ pub(crate) fn clear_external_overlaps(
     let sg_gap = SUBGRAPH_H_PAD * 2 + SIBLING_GAP;
 
     for _round in 0..8 {
-        // ── Project per-cluster x-envelopes + level ranges ──
-        let mut bbox: Vec<Option<(usize, usize)>> = vec![None; sg_count];
-        let mut range: Vec<(usize, usize)> = vec![(usize::MAX, 0); sg_count];
-
-        for (node_idx, &(lvl, _, x, w)) in real_node_coords.iter().enumerate() {
-            if let Some(si) = node_sg.get(node_idx).copied().flatten() {
-                let r = x + w;
-                bbox[si] = Some(match bbox[si] {
-                    None => (x, r),
-                    Some((l, rr)) => (l.min(x), rr.max(r)),
-                });
-                let mut cur = Some(si);
-                while let Some(i) = cur {
-                    range[i].0 = range[i].0.min(lvl);
-                    range[i].1 = range[i].1.max(lvl);
-                    cur = parent_idx[i];
-                }
-            }
-        }
-
-        // Pad + label minimum (mirrors compute_bounding_boxes pass 1.5).
-        for (si, b) in bbox.iter_mut().enumerate() {
-            if let Some((l, r)) = *b {
-                let left = l.saturating_sub(SUBGRAPH_H_PAD);
-                let mut right = r + SUBGRAPH_H_PAD;
-                let min_label_width = label_min_width(dag.subgraphs[si].label);
-                if right - left < min_label_width {
-                    right = left + min_label_width;
-                }
-                *b = Some((left, right));
-            }
-        }
-
-        // Child → parent expansion, then label recheck (mirrors pass 2).
-        const PARENT_CHILD_H_GAP: usize = 1;
-        for &si in &order {
-            if let (Some((cl, cr)), Some(pi)) = (bbox[si], parent_idx[si]) {
-                let exp = (cl.saturating_sub(PARENT_CHILD_H_GAP), cr + PARENT_CHILD_H_GAP);
-                bbox[pi] = Some(match bbox[pi] {
-                    None => exp,
-                    Some((pl, pr)) => (pl.min(exp.0), pr.max(exp.1)),
-                });
-            }
-        }
-        for (si, b) in bbox.iter_mut().enumerate() {
-            if let Some((l, r)) = *b {
-                let min_label_width = label_min_width(dag.subgraphs[si].label);
-                if r - l < min_label_width {
-                    *b = Some((l, l + min_label_width));
-                }
-            }
-        }
+        let (bbox, range) = project_envelopes(dag, real_node_coords, &node_sg, &parent_idx, &order);
 
         // ── Push overlapping unaffiliated nodes right of each envelope ──
         let mut moved = false;
@@ -563,6 +512,321 @@ pub(crate) fn clear_external_overlaps(
 
     let after_max_right = real_node_coords.iter().map(|c| c.2 + c.3).max().unwrap_or(0);
     after_max_right.saturating_sub(before_max_right)
+}
+
+/// Per-cluster projected x-envelope: `None` if the cluster has no member
+/// nodes, else `(left, right)` including padding and label minimum.
+type Envelopes = Vec<Option<(usize, usize)>>;
+/// Per-cluster `(first_level, last_level)` range (self + descendants).
+type LevelRanges = Vec<(usize, usize)>;
+
+/// Project per-cluster x-envelopes and level ranges from current node
+/// coordinates, mirroring [`compute_bounding_boxes`] x-math: member
+/// extent, `SUBGRAPH_H_PAD`, label minimum width, child → parent
+/// expansion, label recheck. `order` must be deepest-first.
+fn project_envelopes(
+    dag: &Graph<'_>,
+    real_node_coords: &[(usize, usize, usize, usize)],
+    node_sg: &[Option<usize>],
+    parent_idx: &[Option<usize>],
+    order: &[usize],
+) -> (Envelopes, LevelRanges) {
+    let sg_count = parent_idx.len();
+    let mut bbox: Vec<Option<(usize, usize)>> = vec![None; sg_count];
+    let mut range: Vec<(usize, usize)> = vec![(usize::MAX, 0); sg_count];
+
+    for (node_idx, &(lvl, _, x, w)) in real_node_coords.iter().enumerate() {
+        if let Some(si) = node_sg.get(node_idx).copied().flatten() {
+            let r = x + w;
+            bbox[si] = Some(match bbox[si] {
+                None => (x, r),
+                Some((l, rr)) => (l.min(x), rr.max(r)),
+            });
+            let mut cur = Some(si);
+            while let Some(i) = cur {
+                range[i].0 = range[i].0.min(lvl);
+                range[i].1 = range[i].1.max(lvl);
+                cur = parent_idx[i];
+            }
+        }
+    }
+
+    // Pad + label minimum (mirrors compute_bounding_boxes pass 1.5).
+    for (si, b) in bbox.iter_mut().enumerate() {
+        if let Some((l, r)) = *b {
+            let left = l.saturating_sub(SUBGRAPH_H_PAD);
+            let mut right = r + SUBGRAPH_H_PAD;
+            let min_label_width = label_min_width(dag.subgraphs[si].label);
+            if right - left < min_label_width {
+                right = left + min_label_width;
+            }
+            *b = Some((left, right));
+        }
+    }
+
+    // Child → parent expansion, then label recheck (mirrors pass 2).
+    const PARENT_CHILD_H_GAP: usize = 1;
+    for &si in order {
+        if let (Some((cl, cr)), Some(pi)) = (bbox[si], parent_idx[si]) {
+            let exp = (cl.saturating_sub(PARENT_CHILD_H_GAP), cr + PARENT_CHILD_H_GAP);
+            bbox[pi] = Some(match bbox[pi] {
+                None => exp,
+                Some((pl, pr)) => (pl.min(exp.0), pr.max(exp.1)),
+            });
+        }
+    }
+    for (si, b) in bbox.iter_mut().enumerate() {
+        if let Some((l, r)) = *b {
+            let min_label_width = label_min_width(dag.subgraphs[si].label);
+            if r - l < min_label_width {
+                *b = Some((l, l + min_label_width));
+            }
+        }
+    }
+    (bbox, range)
+}
+
+/// Compact root clusters and unaffiliated nodes leftward.
+///
+/// [`fix_subgraph_overlaps`] separates overlapping clusters by shifting
+/// the right one further right, and nothing pulls clusters back together
+/// afterward — leaving wide empty gulfs crossed by long edge lines. This
+/// pass treats each **root** cluster as a rigid body (its internal layout
+/// and nested children move as one) and each unaffiliated node as a
+/// singleton body, sweeps bodies in left-to-right order, and shifts each
+/// as far left as the per-level frontier of already-placed bodies allows:
+/// envelope↔envelope keeps [`SIBLING_GAP`], envelope↔node keeps
+/// [`ENVELOPE_CLEARANCE`], node↔node keeps `node_spacing`. Shift-left
+/// only, so the canvas can only shrink and no constraint that held
+/// before can break.
+///
+/// Returns the reclaimed canvas width: the reduction of the rightmost
+/// extent, conservatively the smaller of the node-extent and
+/// envelope-extent reductions.
+pub(crate) fn compact_clusters(
+    dag: &Graph<'_>,
+    real_node_coords: &mut [(usize, usize, usize, usize)], // (level, pos, x, width)
+    virtual_levels: &[Vec<VNode>],
+    x_coords: &mut [Vec<usize>],
+    node_levels: &[usize],
+    node_spacing: usize,
+) -> usize {
+    let sg_count = dag.subgraphs.len();
+    if sg_count == 0 || real_node_coords.is_empty() {
+        return 0;
+    }
+
+    let sg_id_to_idx: HashMap<usize, usize> = dag
+        .subgraphs
+        .iter()
+        .enumerate()
+        .map(|(i, sg)| (sg.id, i))
+        .collect();
+    let parent_idx: Vec<Option<usize>> = dag
+        .subgraphs
+        .iter()
+        .map(|sg| sg.parent_id.and_then(|pid| sg_id_to_idx.get(&pid).copied()))
+        .collect();
+    let mut depths = vec![0usize; sg_count];
+    for i in 0..sg_count {
+        let mut d = 0;
+        let mut cur = parent_idx[i];
+        while let Some(p) = cur {
+            d += 1;
+            cur = parent_idx[p];
+        }
+        depths[i] = d;
+    }
+    let mut order: Vec<usize> = (0..sg_count).collect();
+    order.sort_by(|a, b| depths[*b].cmp(&depths[*a]));
+    let node_sg: Vec<Option<usize>> = dag
+        .nodes
+        .iter()
+        .map(|&(nid, _)| {
+            dag.node_subgraph
+                .get(&nid)
+                .and_then(|sid| sg_id_to_idx.get(sid).copied())
+        })
+        .collect();
+    let root_of = |mut i: usize| -> usize {
+        while let Some(p) = parent_idx[i] {
+            i = p;
+        }
+        i
+    };
+
+    let (bbox, range) = project_envelopes(dag, real_node_coords, &node_sg, &parent_idx, &order);
+    let max_level = real_node_coords.iter().map(|c| c.0).max().unwrap_or(0);
+    let before_node_right = real_node_coords.iter().map(|c| c.2 + c.3).max().unwrap_or(0);
+    let before_env_right = bbox.iter().flatten().map(|b| b.1).max().unwrap_or(0);
+
+    // Bodies: root clusters + unaffiliated nodes, in left-to-right order.
+    // (left, right, is_cluster, index)
+    let mut bodies: Vec<(usize, usize, bool, usize)> = Vec::new();
+    for si in 0..sg_count {
+        if parent_idx[si].is_none() {
+            if let Some((l, r)) = bbox[si] {
+                bodies.push((l, r, true, si));
+            }
+        }
+    }
+    for (ni, &(_, _, x, w)) in real_node_coords.iter().enumerate() {
+        if node_sg[ni].is_none() {
+            bodies.push((x, x + w, false, ni));
+        }
+    }
+    bodies.sort_unstable();
+
+    // Per-level frontiers of already-placed bodies.
+    let mut env_right: Vec<Option<usize>> = vec![None; max_level + 1];
+    let mut node_right: Vec<Option<usize>> = vec![None; max_level + 1];
+    // Shift applied to each real node, for realigning dummy waypoints below.
+    let mut delta_of_node: Vec<usize> = vec![0; real_node_coords.len()];
+
+    for &(env_left, env_r, is_cluster, idx) in &bodies {
+        if is_cluster {
+            let (first, last) = range[idx];
+            if first == usize::MAX {
+                continue;
+            }
+            let mut allowed = 0usize;
+            for lvl in first..=last.min(max_level) {
+                if let Some(er) = env_right[lvl] {
+                    allowed = allowed.max(er + SIBLING_GAP);
+                }
+                if let Some(nr) = node_right[lvl] {
+                    allowed = allowed.max(nr + ENVELOPE_CLEARANCE);
+                }
+            }
+            let delta = env_left.saturating_sub(allowed);
+            if delta > 0 {
+                for (ni, coords) in real_node_coords.iter_mut().enumerate() {
+                    if let Some(si) = node_sg[ni] {
+                        if root_of(si) == idx {
+                            coords.2 -= delta;
+                            delta_of_node[ni] = delta;
+                        }
+                    }
+                }
+            }
+            let new_right = env_r - delta;
+            for lvl in first..=last.min(max_level) {
+                env_right[lvl] = Some(env_right[lvl].map_or(new_right, |e| e.max(new_right)));
+            }
+        } else {
+            let (lvl, _, x, w) = real_node_coords[idx];
+            let mut allowed = 0usize;
+            if let Some(er) = env_right[lvl] {
+                allowed = allowed.max(er + ENVELOPE_CLEARANCE);
+            }
+            if let Some(nr) = node_right[lvl] {
+                allowed = allowed.max(nr + node_spacing);
+            }
+            let delta = x.saturating_sub(allowed);
+            if delta > 0 {
+                real_node_coords[idx].2 = x - delta;
+                delta_of_node[idx] = delta;
+            }
+            node_right[lvl] = Some(node_right[lvl].map_or(x - delta + w, |e| e.max(x - delta + w)));
+        }
+    }
+
+    // Realign dummy waypoints with the bodies that moved: an edge's dummy
+    // chain shifts by the interpolation of its endpoints' shifts across the
+    // levels it spans, so the chain stays connected to both ends instead of
+    // being left at its pre-compaction columns (which would draw the edge
+    // straight through whatever moved underneath it).
+    for (lvl, vnodes) in virtual_levels.iter().enumerate() {
+        for (pos, vnode) in vnodes.iter().enumerate() {
+            let VNode::Dummy { edge_idx } = vnode else {
+                continue;
+            };
+            let (from_id, to_id, _) = dag.edges[*edge_idx];
+            let (Some(f), Some(t)) = (dag.node_index(from_id), dag.node_index(to_id)) else {
+                continue;
+            };
+            if f >= delta_of_node.len() || t >= delta_of_node.len() {
+                continue;
+            }
+            let df = delta_of_node[f] as i64;
+            let dt = delta_of_node[t] as i64;
+            let lf = node_levels.get(f).copied().unwrap_or(0) as i64;
+            let lt = node_levels.get(t).copied().unwrap_or(0) as i64;
+            // Snap to the nearer endpoint's shift (not a smooth ramp): the
+            // chain stays straight in two runs with at most one jog at the
+            // midpoint, instead of jogging a little on every level.
+            let delta = if (lvl as i64 - lf).abs() <= (lt - lvl as i64).abs() {
+                df
+            } else {
+                dt
+            };
+            if let Some(x) = x_coords.get_mut(lvl).and_then(|l| l.get_mut(pos)) {
+                *x = x.saturating_sub(delta as usize);
+            }
+        }
+    }
+
+    let (bbox_after, _) = project_envelopes(dag, real_node_coords, &node_sg, &parent_idx, &order);
+    let after_node_right = real_node_coords.iter().map(|c| c.2 + c.3).max().unwrap_or(0);
+    let after_env_right = bbox_after.iter().flatten().map(|b| b.1).max().unwrap_or(0);
+    let node_reclaim = before_node_right.saturating_sub(after_node_right);
+    let env_reclaim = before_env_right.saturating_sub(after_env_right);
+    node_reclaim.min(env_reclaim)
+}
+
+/// Nudge dummy waypoints out of real node spans.
+///
+/// The vertical segment of a skip-level edge is drawn at its waypoint
+/// column, and that column crosses the node row of every level the edge
+/// passes through. After the coordinate passes move real nodes (overlap
+/// repair, tightening, compaction), a node can land on a stale waypoint
+/// column — the edge then renders straight through the node text. This
+/// pass moves any such waypoint to the nearest column outside the node's
+/// span. An edge crossing a subgraph *border* renders with junction
+/// glyphs and is acceptable; crossing a *node* never is, so only node
+/// spans are avoided.
+pub(crate) fn nudge_dummies_off_nodes(
+    virtual_levels: &[Vec<VNode>],
+    x_coords: &mut [Vec<usize>],
+    real_node_coords: &[(usize, usize, usize, usize)], // (level, pos, x, width)
+) {
+    let num_levels = virtual_levels.len();
+    let mut spans: Vec<Vec<(usize, usize)>> = vec![Vec::new(); num_levels];
+    for &(lvl, _, x, w) in real_node_coords {
+        if lvl < num_levels {
+            spans[lvl].push((x, x + w));
+        }
+    }
+    for s in spans.iter_mut() {
+        s.sort_unstable();
+    }
+
+    for (lvl, vnodes) in virtual_levels.iter().enumerate() {
+        for (pos, vnode) in vnodes.iter().enumerate() {
+            let VNode::Dummy { edge_idx } = vnode else {
+                continue;
+            };
+            // The renderer draws this edge's vertical at x + (edge_idx % 4).
+            let off = edge_idx % 4;
+            let Some(&x) = x_coords.get(lvl).and_then(|l| l.get(pos)) else {
+                continue;
+            };
+            let mut col = x + off;
+            for _ in 0..8 {
+                let Some(&(sl, sr)) = spans[lvl].iter().find(|&&(sl, sr)| col >= sl && col < sr)
+                else {
+                    break;
+                };
+                // Exit on the nearer side; going left past column `off` is
+                // impossible (the stored x is unsigned), so fall back right.
+                let go_left = sl > off && (col - sl) < (sr - col);
+                col = if go_left { sl - 1 } else { sr };
+            }
+            if col != x + off {
+                x_coords[lvl][pos] = col - off;
+            }
+        }
+    }
 }
 
 // ── Sibling subgraph overlap repair ──────────────────────────────────────

--- a/src/algorithms/sugiyama/subgraph.rs
+++ b/src/algorithms/sugiyama/subgraph.rs
@@ -233,6 +233,138 @@ pub(crate) fn subgraph_padding(
 /// Gap (in chars) between a cluster's drawn border and an external node.
 const ENVELOPE_CLEARANCE: usize = 1;
 
+/// Reclaim horizontal slack on each level (post-shift tightening).
+///
+/// Sibling-overlap repair moves whole clusters right, which can leave a
+/// node far from its connected neighbors (e.g. a hole where a sibling's
+/// member used to sit before its cluster was shifted away). This pass
+/// sweeps each level in x order and moves every real node toward the
+/// median center of its connected neighbors, strictly bounded by its
+/// current level neighbors — so it can never widen a level, and the
+/// rightmost node may only move left. Runs a few sweeps; each move is
+/// monotone toward the target, so it settles quickly.
+pub(crate) fn tighten_levels(
+    dag: &Graph<'_>,
+    real_node_coords: &mut [(usize, usize, usize, usize)], // (level, pos, x, width)
+    node_spacing: usize,
+) {
+    let n_nodes = real_node_coords.len();
+    if n_nodes < 2 {
+        return;
+    }
+
+    // Undirected adjacency over real nodes (edge endpoints).
+    let mut adjacency: Vec<Vec<usize>> = vec![Vec::new(); n_nodes];
+    for &(from_id, to_id, _) in &dag.edges {
+        if let (Some(f), Some(t)) = (dag.node_index(from_id), dag.node_index(to_id)) {
+            if f != t && f < n_nodes && t < n_nodes {
+                adjacency[f].push(t);
+                adjacency[t].push(f);
+            }
+        }
+    }
+
+    // Immediate subgraph per node, for gap selection.
+    let node_sg: Vec<Option<usize>> = dag
+        .nodes
+        .iter()
+        .map(|&(nid, _)| dag.node_subgraph.get(&nid).copied())
+        .collect();
+    let sg_gap = SUBGRAPH_H_PAD * 2 + SIBLING_GAP;
+
+    // Group node indices by level.
+    let max_level = real_node_coords.iter().map(|c| c.0).max().unwrap_or(0);
+    let mut levels: Vec<Vec<usize>> = vec![Vec::new(); max_level + 1];
+    for (ni, &(lvl, _, _, _)) in real_node_coords.iter().enumerate() {
+        levels[lvl].push(ni);
+    }
+
+    for _sweep in 0..4 {
+        let mut moved = false;
+
+        // Snapshot each immediate cluster's member extent (min x, max right)
+        // across all levels. Members may only move within it, so no cluster
+        // bounding box can grow — growth would re-overlap sibling boxes that
+        // fix_subgraph_overlaps just separated.
+        let mut extents: HashMap<usize, (usize, usize)> = HashMap::new();
+        for (ni, &(_, _, x, w)) in real_node_coords.iter().enumerate() {
+            if let Some(sg) = node_sg[ni] {
+                let e = extents.entry(sg).or_insert((usize::MAX, 0));
+                e.0 = e.0.min(x);
+                e.1 = e.1.max(x + w);
+            }
+        }
+
+        for level_nodes in levels.iter_mut() {
+            let n = level_nodes.len();
+            if n == 0 {
+                continue;
+            }
+            level_nodes.sort_by_key(|&ni| (real_node_coords[ni].2, ni));
+
+            for k in 0..n {
+                let ni = level_nodes[k];
+                let (_, _, x, w) = real_node_coords[ni];
+
+                // Median center of connected neighbors.
+                let mut centers: Vec<usize> = adjacency[ni]
+                    .iter()
+                    .map(|&nb| real_node_coords[nb].2 + real_node_coords[nb].3 / 2)
+                    .collect();
+                if centers.is_empty() {
+                    continue;
+                }
+                centers.sort_unstable();
+                let target_center = centers[centers.len() / 2];
+                let desired = target_center.saturating_sub(w / 2);
+
+                let mut min_x = if k == 0 {
+                    if node_sg[ni].is_some() { SUBGRAPH_H_PAD } else { 0 }
+                } else {
+                    let prev = level_nodes[k - 1];
+                    let gap = if node_sg[prev] != node_sg[ni]
+                        && (node_sg[prev].is_some() || node_sg[ni].is_some())
+                    {
+                        sg_gap
+                    } else {
+                        node_spacing
+                    };
+                    real_node_coords[prev].2 + real_node_coords[prev].3 + gap
+                };
+                let mut max_x = if k + 1 < n {
+                    let next = level_nodes[k + 1];
+                    let gap = if node_sg[next] != node_sg[ni]
+                        && (node_sg[next].is_some() || node_sg[ni].is_some())
+                    {
+                        sg_gap
+                    } else {
+                        node_spacing
+                    };
+                    real_node_coords[next].2.saturating_sub(gap + w)
+                } else {
+                    // Rightmost node: never move right (keeps canvas bounded).
+                    x
+                };
+                if let Some((ext_lo, ext_hi)) = node_sg[ni].and_then(|sg| extents.get(&sg)) {
+                    min_x = min_x.max(*ext_lo);
+                    max_x = max_x.min(ext_hi.saturating_sub(w));
+                }
+                if max_x < min_x {
+                    continue;
+                }
+                let new_x = desired.clamp(min_x, max_x);
+                if new_x != x {
+                    real_node_coords[ni].2 = new_x;
+                    moved = true;
+                }
+            }
+        }
+        if !moved {
+            break;
+        }
+    }
+}
+
 /// Push unaffiliated nodes clear of subgraph bounding-box envelopes
 /// (cluster-width feedback).
 ///

--- a/src/algorithms/sugiyama/subgraph.rs
+++ b/src/algorithms/sugiyama/subgraph.rs
@@ -11,7 +11,11 @@
 //!    [`subgraph_padding`] inserts horizontal padding at subgraph boundary
 //!    transitions so borders don't overprint node text.
 //!
-//! 2. **After final coordinate assignment:**
+//! 2. **After sibling overlap repair ([`fix_subgraph_overlaps`]):**
+//!    [`clear_external_overlaps`] pushes unaffiliated nodes clear of each
+//!    cluster's projected border envelope (cluster-width feedback).
+//!
+//! 3. **After final coordinate assignment:**
 //!    [`compute_bounding_boxes`] walks the node list to emit
 //!    [`SubgraphInfo`] bounding boxes, propagating nested children
 //!    bottom-up.
@@ -129,6 +133,21 @@ pub(crate) fn block_partition_level(dag: &Graph<'_>, level: &[VNode]) -> Vec<VNo
 /// Per-subgraph horizontal padding constant (chars on each side of a border).
 const SUBGRAPH_H_PAD: usize = 2;
 
+/// Cap on how far a subgraph *label* may widen its bounding box.
+///
+/// A box is always wide enough for its member nodes; the label only
+/// forces extra width up to this total. Longer labels are truncated by
+/// the renderers (which clip to `width - 4`). Without a cap, a
+/// pathological heading would blow up the canvas — and with it the
+/// render buffer — linearly in the label length.
+const SUBGRAPH_LABEL_BOX_CAP: usize = 40;
+
+/// Minimum box width needed to show `label` (borders + spaces), capped.
+#[inline]
+fn label_min_width(label: &str) -> usize {
+    (label.len() + 4).min(SUBGRAPH_LABEL_BOX_CAP)
+}
+
 /// Vertical padding above first node: border row + label row + 1 blank row.
 pub(crate) const SUBGRAPH_V_PAD_TOP: usize = 3; // ╔═══╗ + ║ Label ║ + ║     ║
 /// Vertical padding below last node: 1 blank row + border row.
@@ -207,6 +226,211 @@ pub(crate) fn subgraph_padding(
     }
 
     level_widths
+}
+
+// ── Cluster-width feedback ───────────────────────────────────────────────
+
+/// Gap (in chars) between a cluster's drawn border and an external node.
+const ENVELOPE_CLEARANCE: usize = 1;
+
+/// Push unaffiliated nodes clear of subgraph bounding-box envelopes
+/// (cluster-width feedback).
+///
+/// [`subgraph_padding`] reserves space per level, but the border later
+/// drawn from [`compute_bounding_boxes`] is a *global* x-envelope: the
+/// member extent across all levels, padded, widened to fit the label,
+/// and expanded around children. Without feedback, an external node on
+/// a narrower level (or past a label-widened edge) renders *inside* the
+/// cluster border. This pass projects each cluster's final x-envelope
+/// with the same math and pushes overlapping external nodes to its
+/// right, iterating (bounded rounds) since a sweep can grow another
+/// cluster's envelope.
+///
+/// It runs on `real_node_coords` **after** [`fix_subgraph_overlaps`] so
+/// it sees the same coordinates the bounding boxes are computed from —
+/// running earlier would clear against envelopes that sibling-overlap
+/// repair later shifts.
+///
+/// Only **unaffiliated real nodes** are pushed:
+/// - Members of *other* clusters are left to [`fix_subgraph_overlaps`],
+///   which moves whole clusters. Pushing them individually here would
+///   stretch their cluster's envelope and cascade the widening.
+/// - Dummy vnodes are never pushed — an edge crossing a border renders
+///   with junction glyphs, and rerouting them costs unbounded width.
+///
+/// Returns the growth of the maximum node right edge (0 if nothing
+/// moved), which the caller folds into the canvas width.
+pub(crate) fn clear_external_overlaps(
+    dag: &Graph<'_>,
+    real_node_coords: &mut [(usize, usize, usize, usize)], // (level, pos, x, width)
+    node_spacing: usize,
+) -> usize {
+    let sg_count = dag.subgraphs.len();
+    if sg_count == 0 || real_node_coords.is_empty() {
+        return 0;
+    }
+
+    let sg_id_to_idx: HashMap<usize, usize> = dag
+        .subgraphs
+        .iter()
+        .enumerate()
+        .map(|(i, sg)| (sg.id, i))
+        .collect();
+    let parent_idx: Vec<Option<usize>> = dag
+        .subgraphs
+        .iter()
+        .map(|sg| sg.parent_id.and_then(|pid| sg_id_to_idx.get(&pid).copied()))
+        .collect();
+
+    // Deepest-first order for child → parent envelope propagation.
+    let mut depths = vec![0usize; sg_count];
+    for i in 0..sg_count {
+        let mut d = 0;
+        let mut cur = parent_idx[i];
+        while let Some(p) = cur {
+            d += 1;
+            cur = parent_idx[p];
+        }
+        depths[i] = d;
+    }
+    let mut order: Vec<usize> = (0..sg_count).collect();
+    order.sort_by(|a, b| depths[*b].cmp(&depths[*a]));
+
+    // Immediate subgraph index per node (None = unaffiliated).
+    let node_sg: Vec<Option<usize>> = dag
+        .nodes
+        .iter()
+        .map(|&(nid, _)| {
+            dag.node_subgraph
+                .get(&nid)
+                .and_then(|sid| sg_id_to_idx.get(sid).copied())
+        })
+        .collect();
+
+    let max_level = real_node_coords.iter().map(|c| c.0).max().unwrap_or(0);
+    let before_max_right = real_node_coords.iter().map(|c| c.2 + c.3).max().unwrap_or(0);
+
+    // Same cross-boundary gap the refinement passes use.
+    let sg_gap = SUBGRAPH_H_PAD * 2 + SIBLING_GAP;
+
+    for _round in 0..8 {
+        // ── Project per-cluster x-envelopes + level ranges ──
+        let mut bbox: Vec<Option<(usize, usize)>> = vec![None; sg_count];
+        let mut range: Vec<(usize, usize)> = vec![(usize::MAX, 0); sg_count];
+
+        for (node_idx, &(lvl, _, x, w)) in real_node_coords.iter().enumerate() {
+            if let Some(si) = node_sg.get(node_idx).copied().flatten() {
+                let r = x + w;
+                bbox[si] = Some(match bbox[si] {
+                    None => (x, r),
+                    Some((l, rr)) => (l.min(x), rr.max(r)),
+                });
+                let mut cur = Some(si);
+                while let Some(i) = cur {
+                    range[i].0 = range[i].0.min(lvl);
+                    range[i].1 = range[i].1.max(lvl);
+                    cur = parent_idx[i];
+                }
+            }
+        }
+
+        // Pad + label minimum (mirrors compute_bounding_boxes pass 1.5).
+        for (si, b) in bbox.iter_mut().enumerate() {
+            if let Some((l, r)) = *b {
+                let left = l.saturating_sub(SUBGRAPH_H_PAD);
+                let mut right = r + SUBGRAPH_H_PAD;
+                let min_label_width = label_min_width(dag.subgraphs[si].label);
+                if right - left < min_label_width {
+                    right = left + min_label_width;
+                }
+                *b = Some((left, right));
+            }
+        }
+
+        // Child → parent expansion, then label recheck (mirrors pass 2).
+        const PARENT_CHILD_H_GAP: usize = 1;
+        for &si in &order {
+            if let (Some((cl, cr)), Some(pi)) = (bbox[si], parent_idx[si]) {
+                let exp = (cl.saturating_sub(PARENT_CHILD_H_GAP), cr + PARENT_CHILD_H_GAP);
+                bbox[pi] = Some(match bbox[pi] {
+                    None => exp,
+                    Some((pl, pr)) => (pl.min(exp.0), pr.max(exp.1)),
+                });
+            }
+        }
+        for (si, b) in bbox.iter_mut().enumerate() {
+            if let Some((l, r)) = *b {
+                let min_label_width = label_min_width(dag.subgraphs[si].label);
+                if r - l < min_label_width {
+                    *b = Some((l, l + min_label_width));
+                }
+            }
+        }
+
+        // ── Push overlapping unaffiliated nodes right of each envelope ──
+        let mut moved = false;
+        let mut touched = vec![false; max_level + 1];
+        for si in 0..sg_count {
+            let Some((left, right)) = bbox[si] else {
+                continue;
+            };
+            let (first, last) = range[si];
+            if first == usize::MAX {
+                continue;
+            }
+            let mut cursors = vec![0usize; max_level + 1];
+            for c in cursors[first..=last.min(max_level)].iter_mut() {
+                *c = right + ENVELOPE_CLEARANCE;
+            }
+            for node_idx in 0..real_node_coords.len() {
+                if node_sg.get(node_idx).copied().flatten().is_some() {
+                    continue;
+                }
+                let (lvl, _, x, w) = real_node_coords[node_idx];
+                if lvl < first || lvl > last {
+                    continue;
+                }
+                if x < right && x + w > left {
+                    real_node_coords[node_idx].2 = cursors[lvl];
+                    cursors[lvl] += w + node_spacing;
+                    moved = true;
+                    touched[lvl] = true;
+                }
+            }
+        }
+        if !moved {
+            break;
+        }
+
+        // ── Re-establish min gaps on touched levels (push-right, x order) ──
+        for (lvl, lvl_touched) in touched.iter().enumerate() {
+            if !lvl_touched {
+                continue;
+            }
+            let mut level_nodes: Vec<usize> = (0..real_node_coords.len())
+                .filter(|&ni| real_node_coords[ni].0 == lvl)
+                .collect();
+            level_nodes.sort_by_key(|&ni| (real_node_coords[ni].2, ni));
+            for k in 1..level_nodes.len() {
+                let prev = level_nodes[k - 1];
+                let cur = level_nodes[k];
+                let prev_sg = node_sg[prev];
+                let cur_sg = node_sg[cur];
+                let gap = if prev_sg != cur_sg && (prev_sg.is_some() || cur_sg.is_some()) {
+                    sg_gap
+                } else {
+                    node_spacing
+                };
+                let min_x = real_node_coords[prev].2 + real_node_coords[prev].3 + gap;
+                if real_node_coords[cur].2 < min_x {
+                    real_node_coords[cur].2 = min_x;
+                }
+            }
+        }
+    }
+
+    let after_max_right = real_node_coords.iter().map(|c| c.2 + c.3).max().unwrap_or(0);
+    after_max_right.saturating_sub(before_max_right)
 }
 
 // ── Sibling subgraph overlap repair ──────────────────────────────────────
@@ -385,7 +609,7 @@ pub(crate) fn fix_subgraph_overlaps(
                 env.map(|(mn, mx)| {
                     let left = mn.saturating_sub(SUBGRAPH_H_PAD);
                     let right = mx + SUBGRAPH_H_PAD;
-                    let label_w = dag.subgraphs[sg_idx].label.len() + 4;
+                    let label_w = label_min_width(dag.subgraphs[sg_idx].label);
                     let width = right.saturating_sub(left);
                     let right = if width < label_w {
                         left + label_w
@@ -806,7 +1030,7 @@ pub(crate) fn compute_bounding_boxes<'a>(
             };
             // Ensure width fits the label: ║ Label ║ needs label_len + 4
             let width = right.saturating_sub(x);
-            let min_label_width = sg.label.len() + 4;
+            let min_label_width = label_min_width(sg.label);
             let right = if width < min_label_width {
                 x + min_label_width
             } else {
@@ -855,7 +1079,7 @@ pub(crate) fn compute_bounding_boxes<'a>(
         if let Some((x, y, right, bottom)) = bboxes[sg_idx] {
             // Re-check label width (parent may have grown but label still needs room)
             let width = right.saturating_sub(x);
-            let min_label_width = sg.label.len() + 4;
+            let min_label_width = label_min_width(sg.label);
             let right = if width < min_label_width {
                 x + min_label_width
             } else {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1368,6 +1368,195 @@ mod tests {
     }
 
     #[test]
+    fn levels_tighten_after_sibling_cluster_shifts() {
+        // Tier-2 pattern from examples/subgraph_stress.rs: crossing
+        // reduction orders Analytics between the two Core DBs; sibling
+        // overlap repair then shifts Data Pipeline right, leaving a hole.
+        // tighten_levels must reclaim it so children align with parents.
+        let mut g = Graph::new();
+        for (id, label) in [
+            (1, "LoadBalancer"),
+            (2, "CDN"),
+            (10, "WebApp"),
+            (11, "MobileAPI"),
+            (12, "SSR-Engine"),
+            (20, "AuthSvc"),
+            (21, "SessionDB"),
+            (22, "UserSvc"),
+            (23, "ProfileDB"),
+            (30, "Analytics"),
+            (31, "Warehouse"),
+            (32, "ETL"),
+        ] {
+            g.add_node(id, label);
+        }
+        for (f, t) in [
+            (1, 10),
+            (1, 11),
+            (2, 12),
+            (10, 20),
+            (11, 20),
+            (12, 22),
+            (20, 21),
+            (22, 23),
+            (20, 30),
+            (22, 30),
+            (30, 31),
+            (30, 32),
+        ] {
+            g.add_edge(f, t, None);
+        }
+        let frontend = g.add_subgraph("Frontend");
+        let backend = g.add_subgraph("Backend");
+        let core = g.add_subgraph("Core");
+        let data = g.add_subgraph("Data Pipeline");
+        g.put_nodes(&[10, 11, 12]).inside(frontend).unwrap();
+        g.put_nodes(&[20, 21, 22, 23]).inside(core).unwrap();
+        g.put_nodes(&[30, 31, 32]).inside(data).unwrap();
+        g.put_subgraphs(&[core, data]).inside(backend).unwrap();
+
+        let ir = g.compute_layout();
+        let center = |label: &str| {
+            let n = ir.nodes().iter().find(|n| n.label == label).unwrap();
+            n.x + n.width / 2
+        };
+        assert!(
+            center("SessionDB").abs_diff(center("AuthSvc")) <= 3,
+            "SessionDB (center {}) should sit under AuthSvc (center {})",
+            center("SessionDB"),
+            center("AuthSvc"),
+        );
+        assert!(
+            center("ProfileDB").abs_diff(center("UserSvc")) <= 3,
+            "ProfileDB (center {}) should sit under UserSvc (center {})",
+            center("ProfileDB"),
+            center("UserSvc"),
+        );
+    }
+
+    #[test]
+    fn tightening_never_overlaps_disjoint_boxes() {
+        // Tier-3 pattern from examples/subgraph_stress.rs: ArgoCD (CI/CD)
+        // has children deep inside eu-west-1. Tightening must not pull it
+        // out of the CI/CD envelope — that would expand the CI/CD box into
+        // the eu-west-1 box after the sibling shifts already separated them.
+        let mut g = Graph::new();
+        for (id, label) in [
+            (1, "ALB"),
+            (2, "WAF"),
+            (3, "Web-A1"),
+            (4, "App-A1"),
+            (5, "DB-A1"),
+            (6, "Web-A2"),
+            (7, "App-A2"),
+            (8, "DB-A2"),
+            (9, "Web-B1"),
+            (10, "App-B1"),
+            (11, "Redis-B1"),
+            (12, "DB-B1"),
+            (13, "Web-B2"),
+            (14, "App-B2"),
+            (15, "Redis-B2"),
+            (16, "DB-B2"),
+            (17, "RabbitMQ"),
+            (18, "S3-Bucket"),
+            (19, "Vault"),
+            (20, "Jenkins"),
+            (21, "ArgoCD"),
+            (22, "ECR"),
+            (23, "Prometheus"),
+            (24, "Grafana"),
+            (25, "Loki"),
+        ] {
+            g.add_node(id, label);
+        }
+        for (f, t) in [
+            (1, 2),
+            (2, 3),
+            (3, 4),
+            (4, 5),
+            (2, 6),
+            (6, 7),
+            (7, 8),
+            (2, 9),
+            (9, 10),
+            (10, 11),
+            (11, 12),
+            (2, 13),
+            (13, 14),
+            (14, 15),
+            (15, 16),
+            (4, 17),
+            (10, 17),
+            (17, 18),
+            (20, 22),
+            (22, 21),
+            (21, 3),
+            (21, 9),
+            (23, 24),
+            (25, 24),
+            (4, 23),
+            (10, 25),
+        ] {
+            g.add_edge(f, t, None);
+        }
+        let az_a1 = g.add_subgraph("AZ-1");
+        let az_a2 = g.add_subgraph("AZ-2");
+        let region_a = g.add_subgraph("us-east-1");
+        g.put_nodes(&[3, 4, 5]).inside(az_a1).unwrap();
+        g.put_nodes(&[6, 7, 8]).inside(az_a2).unwrap();
+        g.put_subgraphs(&[az_a1, az_a2]).inside(region_a).unwrap();
+        let az_b1 = g.add_subgraph("AZ-1");
+        let az_b2 = g.add_subgraph("AZ-2");
+        let region_b = g.add_subgraph("eu-west-1");
+        g.put_nodes(&[9, 10, 11, 12]).inside(az_b1).unwrap();
+        g.put_nodes(&[13, 14, 15, 16]).inside(az_b2).unwrap();
+        g.put_subgraphs(&[az_b1, az_b2]).inside(region_b).unwrap();
+        let shared = g.add_subgraph("Shared Services");
+        g.put_nodes(&[17, 18, 19]).inside(shared).unwrap();
+        let cicd = g.add_subgraph("CI/CD");
+        g.put_nodes(&[20, 21, 22]).inside(cicd).unwrap();
+        let obs = g.add_subgraph("Observability");
+        g.put_nodes(&[23, 24, 25]).inside(obs).unwrap();
+
+        let ir = g.compute_layout();
+        let boxes = ir.subgraphs();
+        let is_ancestor = |anc: usize, mut id: usize| -> bool {
+            loop {
+                let parent = boxes.iter().find(|s| s.id == id).and_then(|s| s.parent_id);
+                match parent {
+                    Some(p) if p == anc => return true,
+                    Some(p) => id = p,
+                    None => return false,
+                }
+            }
+        };
+        for a in boxes {
+            for b in boxes {
+                if a.id >= b.id || is_ancestor(a.id, b.id) || is_ancestor(b.id, a.id) {
+                    continue;
+                }
+                let x_overlap = a.x < b.x + b.width && b.x < a.x + a.width;
+                let y_overlap = a.y < b.y + b.height && b.y < a.y + a.height;
+                assert!(
+                    !(x_overlap && y_overlap),
+                    "boxes '{}' ({},{} {}x{}) and '{}' ({},{} {}x{}) overlap",
+                    a.label,
+                    a.x,
+                    a.y,
+                    a.width,
+                    a.height,
+                    b.label,
+                    b.x,
+                    b.y,
+                    b.width,
+                    b.height,
+                );
+            }
+        }
+    }
+
+    #[test]
     fn book_length_subgraph_label_is_capped() {
         let long_label = "L".repeat(300);
         let mut g = Graph::new();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1327,4 +1327,84 @@ mod tests {
         // exactly (levels - 1) * level_spacing.
         assert_eq!(spaced.height(), base.height() + 4);
     }
+
+    // ── Cluster-width feedback (regression: external nodes rendered
+    //    inside subgraph borders) ────────────────────────────────────────
+
+    fn assert_externals_clear(ir: &crate::ir::LayoutIR<'_>, externals: &[&str]) {
+        for sg in ir.subgraphs() {
+            assert!(
+                sg.x + sg.width <= ir.width(),
+                "canvas clips subgraph '{}' (border right {} > width {})",
+                sg.label,
+                sg.x + sg.width,
+                ir.width(),
+            );
+            for n in ir.nodes().iter().filter(|n| externals.contains(&n.label)) {
+                let x_overlap = n.x < sg.x + sg.width && n.x + n.width > sg.x;
+                let y_overlap = n.y >= sg.y && n.y < sg.y + sg.height;
+                assert!(
+                    !(x_overlap && y_overlap),
+                    "external node '{}' overlaps subgraph '{}' box",
+                    n.label,
+                    sg.label,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn label_widened_subgraph_does_not_swallow_external_nodes() {
+        let mut g = Graph::new();
+        g.add_node(1, "X");
+        g.add_node(2, "E");
+        g.add_node(3, "X2");
+        g.add_node(4, "E2");
+        g.add_edge(1, 3, None);
+        g.add_edge(2, 4, None);
+        let sg = g.add_subgraph("VeryLongSubgraphLabelHere");
+        g.put_nodes(&[1, 3]).inside(sg).unwrap();
+        assert_externals_clear(&g.compute_layout(), &["E", "E2"]);
+    }
+
+    #[test]
+    fn book_length_subgraph_label_is_capped() {
+        let long_label = "L".repeat(300);
+        let mut g = Graph::new();
+        g.add_node(1, "A");
+        g.add_node(2, "B");
+        g.add_edge(1, 2, None);
+        let sg = g.add_subgraph(&long_label);
+        g.put_nodes(&[1, 2]).inside(sg).unwrap();
+        let ir = g.compute_layout();
+        let info = &ir.subgraphs()[0];
+        assert!(
+            info.width <= 40,
+            "label must not widen the box past the cap (got {})",
+            info.width,
+        );
+        assert!(
+            ir.width() < 100,
+            "canvas must not scale with label length (got {})",
+            ir.width(),
+        );
+        // Renderer truncates the label to the box interior.
+        let out = ir.render_scanline();
+        assert!(out.lines().all(|l| l.chars().count() <= ir.width()));
+    }
+
+    #[test]
+    fn cross_level_subgraph_envelope_does_not_swallow_external_nodes() {
+        let mut g = Graph::new();
+        g.add_node(1, "WideMemberNodeAAA");
+        g.add_node(2, "WideMemberNodeBBB");
+        g.add_node(3, "m");
+        g.add_node(4, "ext");
+        g.add_edge(1, 3, None);
+        g.add_edge(2, 3, None);
+        g.add_edge(1, 4, None);
+        let sg = g.add_subgraph("C");
+        g.put_nodes(&[1, 2, 3]).inside(sg).unwrap();
+        assert_externals_clear(&g.compute_layout(), &["ext"]);
+    }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1434,12 +1434,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn tightening_never_overlaps_disjoint_boxes() {
-        // Tier-3 pattern from examples/subgraph_stress.rs: ArgoCD (CI/CD)
-        // has children deep inside eu-west-1. Tightening must not pull it
-        // out of the CI/CD envelope — that would expand the CI/CD box into
-        // the eu-west-1 box after the sibling shifts already separated them.
+    /// Tier-3 pattern from examples/subgraph_stress.rs: nested regions,
+    /// a CI/CD cluster whose member has children deep inside eu-west-1,
+    /// and cross-cluster edges. Shared by the tightening/compaction tests.
+    fn tier3_like_graph() -> Graph<'static> {
         let mut g = Graph::new();
         for (id, label) in [
             (1, "ALB"),
@@ -1518,7 +1516,16 @@ mod tests {
         g.put_nodes(&[20, 21, 22]).inside(cicd).unwrap();
         let obs = g.add_subgraph("Observability");
         g.put_nodes(&[23, 24, 25]).inside(obs).unwrap();
+        g
+    }
 
+    #[test]
+    fn tightening_never_overlaps_disjoint_boxes() {
+        // ArgoCD (CI/CD) has children deep inside eu-west-1. Tightening
+        // must not pull it out of the CI/CD envelope — that would expand
+        // the CI/CD box into the eu-west-1 box after the sibling shifts
+        // already separated them.
+        let g = tier3_like_graph();
         let ir = g.compute_layout();
         let boxes = ir.subgraphs();
         let is_ancestor = |anc: usize, mut id: usize| -> bool {
@@ -1554,6 +1561,418 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Tier-5 pattern from examples/subgraph_stress.rs (80 nodes, 24
+    /// clusters, depth 4): the only known reproducer for stale dummy
+    /// waypoints crossing node text after inter-cluster compaction.
+    fn tier5_like_graph() -> Graph<'static> {
+        let mut g = Graph::new();
+        let mut id = 0usize;
+        let mut next = || {
+            id += 1;
+            id
+        };
+
+        // ── Global Entry ──
+        let dns = next();
+        g.add_node(dns, "Route53");
+        let cdn = next();
+        g.add_node(cdn, "CloudFront");
+        let waf = next();
+        g.add_node(waf, "WAF");
+        g.add_edge(dns, cdn, None);
+        g.add_edge(cdn, waf, None);
+
+        // ── US Region ──
+        //   Frontend
+        let us_web = next();
+        g.add_node(us_web, "US-Web");
+        let us_mobile = next();
+        g.add_node(us_mobile, "US-Mobile");
+        let us_ssr = next();
+        g.add_node(us_ssr, "US-SSR");
+        g.add_edge(waf, us_web, None);
+        g.add_edge(waf, us_mobile, None);
+        g.add_edge(us_web, us_ssr, None);
+
+        //   Auth micro
+        let us_auth = next();
+        g.add_node(us_auth, "US-Auth");
+        let us_token = next();
+        g.add_node(us_token, "US-Token");
+        let us_mfa = next();
+        g.add_node(us_mfa, "US-MFA");
+        g.add_edge(us_web, us_auth, None);
+        g.add_edge(us_mobile, us_auth, None);
+        g.add_edge(us_auth, us_token, None);
+        g.add_edge(us_auth, us_mfa, None);
+
+        //   Biz logic
+        let us_order = next();
+        g.add_node(us_order, "US-Orders");
+        let us_pay = next();
+        g.add_node(us_pay, "US-Pay");
+        let us_inv = next();
+        g.add_node(us_inv, "US-Inv");
+        let us_ship = next();
+        g.add_node(us_ship, "US-Ship");
+        g.add_edge(us_auth, us_order, None);
+        g.add_edge(us_order, us_pay, None);
+        g.add_edge(us_order, us_inv, None);
+        g.add_edge(us_order, us_ship, None);
+
+        //   Databases
+        let us_pg = next();
+        g.add_node(us_pg, "US-Postgres");
+        let us_redis = next();
+        g.add_node(us_redis, "US-Redis");
+        let us_s3 = next();
+        g.add_node(us_s3, "US-S3");
+        g.add_edge(us_order, us_pg, None);
+        g.add_edge(us_pay, us_pg, None);
+        g.add_edge(us_auth, us_redis, None);
+        g.add_edge(us_inv, us_s3, None);
+
+        // ── EU Region (mirror, smaller) ──
+        let eu_web = next();
+        g.add_node(eu_web, "EU-Web");
+        let eu_auth = next();
+        g.add_node(eu_auth, "EU-Auth");
+        let eu_order = next();
+        g.add_node(eu_order, "EU-Orders");
+        let eu_pay = next();
+        g.add_node(eu_pay, "EU-Pay");
+        let eu_ship = next();
+        g.add_node(eu_ship, "EU-Ship");
+        let eu_pg = next();
+        g.add_node(eu_pg, "EU-Postgres");
+        let eu_redis = next();
+        g.add_node(eu_redis, "EU-Redis");
+        g.add_edge(waf, eu_web, None);
+        g.add_edge(eu_web, eu_auth, None);
+        g.add_edge(eu_auth, eu_order, None);
+        g.add_edge(eu_order, eu_pay, None);
+        g.add_edge(eu_order, eu_ship, None);
+        g.add_edge(eu_order, eu_pg, None);
+        g.add_edge(eu_auth, eu_redis, None);
+
+        // ── APAC Region ──
+        let ap_web = next();
+        g.add_node(ap_web, "AP-Web");
+        let ap_auth = next();
+        g.add_node(ap_auth, "AP-Auth");
+        let ap_order = next();
+        g.add_node(ap_order, "AP-Orders");
+        let ap_pg = next();
+        g.add_node(ap_pg, "AP-Postgres");
+        g.add_edge(waf, ap_web, None);
+        g.add_edge(ap_web, ap_auth, None);
+        g.add_edge(ap_auth, ap_order, None);
+        g.add_edge(ap_order, ap_pg, None);
+
+        // ── Messaging Layer ──
+        let kafka1 = next();
+        g.add_node(kafka1, "Kafka-1");
+        let kafka2 = next();
+        g.add_node(kafka2, "Kafka-2");
+        let zk = next();
+        g.add_node(zk, "Zookeeper");
+        let schema = next();
+        g.add_node(schema, "SchemaReg");
+        g.add_edge(us_order, kafka1, None);
+        g.add_edge(eu_order, kafka1, None);
+        g.add_edge(kafka1, kafka2, None);
+        g.add_edge(kafka1, zk, None);
+        g.add_edge(kafka2, schema, None);
+
+        // ── Data Platform ──
+        let spark = next();
+        g.add_node(spark, "Spark");
+        let flink = next();
+        g.add_node(flink, "Flink");
+        let airflow = next();
+        g.add_node(airflow, "Airflow");
+        let datalake = next();
+        g.add_node(datalake, "DataLake");
+        let redshift = next();
+        g.add_node(redshift, "Redshift");
+        let tableau = next();
+        g.add_node(tableau, "Tableau");
+        g.add_edge(kafka2, spark, None);
+        g.add_edge(kafka2, flink, None);
+        g.add_edge(airflow, spark, None);
+        g.add_edge(spark, datalake, None);
+        g.add_edge(flink, datalake, None);
+        g.add_edge(datalake, redshift, None);
+        g.add_edge(redshift, tableau, None);
+
+        // ── ML Platform ──
+        let mlflow = next();
+        g.add_node(mlflow, "MLflow");
+        let sagemaker = next();
+        g.add_node(sagemaker, "SageMaker");
+        let model_reg = next();
+        g.add_node(model_reg, "ModelReg");
+        let inference = next();
+        g.add_node(inference, "Inference");
+        g.add_edge(datalake, mlflow, None);
+        g.add_edge(mlflow, sagemaker, None);
+        g.add_edge(sagemaker, model_reg, None);
+        g.add_edge(model_reg, inference, None);
+        g.add_edge(inference, us_order, None); // predictions feed back
+
+        // ── Observability ──
+        let prom = next();
+        g.add_node(prom, "Prometheus");
+        let grafana = next();
+        g.add_node(grafana, "Grafana");
+        let jaeger = next();
+        g.add_node(jaeger, "Jaeger");
+        let loki = next();
+        g.add_node(loki, "Loki");
+        let cortex = next();
+        g.add_node(cortex, "Cortex");
+        let pager = next();
+        g.add_node(pager, "PagerDuty");
+        let opsgenie = next();
+        g.add_node(opsgenie, "OpsGenie");
+        g.add_edge(us_order, prom, None);
+        g.add_edge(eu_order, prom, None);
+        g.add_edge(prom, cortex, None);
+        g.add_edge(cortex, grafana, None);
+        g.add_edge(prom, jaeger, None);
+        g.add_edge(prom, loki, None);
+        g.add_edge(grafana, pager, None);
+        g.add_edge(grafana, opsgenie, None);
+
+        // ── Security ──
+        let vault = next();
+        g.add_node(vault, "Vault");
+        let cert_mgr = next();
+        g.add_node(cert_mgr, "CertMgr");
+        let guard = next();
+        g.add_node(guard, "GuardDuty");
+        let inspector = next();
+        g.add_node(inspector, "Inspector");
+        g.add_edge(us_auth, vault, None);
+        g.add_edge(eu_auth, vault, None);
+        g.add_edge(vault, cert_mgr, None);
+        g.add_edge(vault, guard, None);
+        g.add_edge(guard, inspector, None);
+
+        // ── DevOps / Platform ──
+        let github = next();
+        g.add_node(github, "GitHub");
+        let ci = next();
+        g.add_node(ci, "Actions");
+        let ecr = next();
+        g.add_node(ecr, "ECR");
+        let argo = next();
+        g.add_node(argo, "ArgoCD");
+        let tf = next();
+        g.add_node(tf, "Terraform");
+        let k8s_us = next();
+        g.add_node(k8s_us, "EKS-US");
+        let k8s_eu = next();
+        g.add_node(k8s_eu, "EKS-EU");
+        let k8s_ap = next();
+        g.add_node(k8s_ap, "EKS-AP");
+        g.add_edge(github, ci, None);
+        g.add_edge(ci, ecr, None);
+        g.add_edge(ecr, argo, None);
+        g.add_edge(argo, k8s_us, None);
+        g.add_edge(argo, k8s_eu, None);
+        g.add_edge(argo, k8s_ap, None);
+        g.add_edge(tf, k8s_us, None);
+        g.add_edge(tf, k8s_eu, None);
+        g.add_edge(tf, k8s_ap, None);
+
+        // ── Notifications ──
+        let sns = next();
+        g.add_node(sns, "SNS");
+        let ses = next();
+        g.add_node(ses, "SES");
+        let slack_hook = next();
+        g.add_node(slack_hook, "Slack");
+        g.add_edge(pager, sns, None);
+        g.add_edge(sns, ses, None);
+        g.add_edge(sns, slack_hook, None);
+
+        // ── Build subgraph hierarchy ──
+
+        // US Region → Frontend, Auth, Business, Data
+        let us_fe = g.add_subgraph("US-Frontend");
+        g.put_nodes(&[us_web, us_mobile, us_ssr])
+            .inside(us_fe)
+            .unwrap();
+        let us_au = g.add_subgraph("US-Auth");
+        g.put_nodes(&[us_auth, us_token, us_mfa])
+            .inside(us_au)
+            .unwrap();
+        let us_biz = g.add_subgraph("US-Business");
+        g.put_nodes(&[us_order, us_pay, us_inv, us_ship])
+            .inside(us_biz)
+            .unwrap();
+        let us_data = g.add_subgraph("US-Data");
+        g.put_nodes(&[us_pg, us_redis, us_s3])
+            .inside(us_data)
+            .unwrap();
+        let region_us = g.add_subgraph("US-East");
+        g.put_subgraphs(&[us_fe, us_au, us_biz, us_data])
+            .inside(region_us)
+            .unwrap();
+
+        // EU Region
+        let eu_svc = g.add_subgraph("EU-Services");
+        g.put_nodes(&[eu_web, eu_auth, eu_order, eu_pay, eu_ship])
+            .inside(eu_svc)
+            .unwrap();
+        let eu_db = g.add_subgraph("EU-Data");
+        g.put_nodes(&[eu_pg, eu_redis]).inside(eu_db).unwrap();
+        let region_eu = g.add_subgraph("EU-West");
+        g.put_subgraphs(&[eu_svc, eu_db]).inside(region_eu).unwrap();
+
+        // APAC Region
+        let region_ap = g.add_subgraph("APAC");
+        g.put_nodes(&[ap_web, ap_auth, ap_order, ap_pg])
+            .inside(region_ap)
+            .unwrap();
+
+        // Messaging
+        let sg_msg = g.add_subgraph("Event Bus");
+        g.put_nodes(&[kafka1, kafka2, zk, schema])
+            .inside(sg_msg)
+            .unwrap();
+
+        // Data Platform
+        let sg_ingest = g.add_subgraph("Ingestion");
+        g.put_nodes(&[spark, flink]).inside(sg_ingest).unwrap();
+        let sg_store = g.add_subgraph("Storage");
+        g.put_nodes(&[datalake, redshift]).inside(sg_store).unwrap();
+        let sg_dp = g.add_subgraph("Data Platform");
+        g.put_nodes(&[airflow, tableau]).inside(sg_dp).unwrap();
+        g.put_subgraphs(&[sg_ingest, sg_store])
+            .inside(sg_dp)
+            .unwrap();
+
+        // ML Platform
+        let sg_ml = g.add_subgraph("ML Platform");
+        g.put_nodes(&[mlflow, sagemaker, model_reg, inference])
+            .inside(sg_ml)
+            .unwrap();
+
+        // Observability
+        let sg_metrics = g.add_subgraph("Metrics");
+        g.put_nodes(&[prom, cortex, grafana])
+            .inside(sg_metrics)
+            .unwrap();
+        let sg_tracing = g.add_subgraph("Tracing");
+        g.put_nodes(&[jaeger, loki]).inside(sg_tracing).unwrap();
+        let sg_alert = g.add_subgraph("Alerting");
+        g.put_nodes(&[pager, opsgenie]).inside(sg_alert).unwrap();
+        let sg_obs = g.add_subgraph("Observability");
+        g.put_subgraphs(&[sg_metrics, sg_tracing, sg_alert])
+            .inside(sg_obs)
+            .unwrap();
+
+        // Security
+        let sg_sec = g.add_subgraph("Security");
+        g.put_nodes(&[vault, cert_mgr, guard, inspector])
+            .inside(sg_sec)
+            .unwrap();
+
+        // DevOps
+        let sg_cicd = g.add_subgraph("CI/CD");
+        g.put_nodes(&[github, ci, ecr, argo])
+            .inside(sg_cicd)
+            .unwrap();
+        let sg_infra = g.add_subgraph("Infrastructure");
+        g.put_nodes(&[tf, k8s_us, k8s_eu, k8s_ap])
+            .inside(sg_infra)
+            .unwrap();
+        let sg_devops = g.add_subgraph("Platform Eng");
+        g.put_subgraphs(&[sg_cicd, sg_infra])
+            .inside(sg_devops)
+            .unwrap();
+
+        // Notifications
+        let sg_notif = g.add_subgraph("Notifications");
+        g.put_nodes(&[sns, ses, slack_hook])
+            .inside(sg_notif)
+            .unwrap();
+
+        g
+    }
+
+    /// Assert no edge's vertical segment runs through node text.
+    fn assert_no_edge_crosses_nodes(ir: &crate::ir::LayoutIR<'_>) {
+        use crate::ir::EdgePath;
+        for edge in ir.edges() {
+            let EdgePath::MultiSegment { waypoints, .. } = &edge.path else {
+                continue;
+            };
+            // Vertical segments: (column, y range) per polyline leg.
+            let mut segments: Vec<(usize, usize, usize)> = Vec::new();
+            if let Some(&(x0, y0)) = waypoints.first() {
+                segments.push((x0, edge.from_y.min(y0), edge.from_y.max(y0)));
+            }
+            for pair in waypoints.windows(2) {
+                let (_, y_prev) = pair[0];
+                let (x, y) = pair[1];
+                segments.push((x, y_prev.min(y), y_prev.max(y)));
+            }
+            if let Some(&(_, y_last)) = waypoints.last() {
+                segments.push((edge.to_x, y_last.min(edge.to_y), y_last.max(edge.to_y)));
+            }
+            for node in ir.nodes() {
+                if node.id == edge.from_id || node.id == edge.to_id {
+                    continue;
+                }
+                for &(col, y0, y1) in &segments {
+                    let x_hit = col >= node.x && col < node.x + node.width;
+                    let y_hit = y0 < node.y + node.height && node.y <= y1;
+                    assert!(
+                        !(x_hit && y_hit),
+                        "edge {}→{} vertical at column {} (rows {}..{}) crosses node '{}' at ({},{} {}x{})",
+                        edge.from_id,
+                        edge.to_id,
+                        col,
+                        y0,
+                        y1,
+                        node.label,
+                        node.x,
+                        node.y,
+                        node.width,
+                        node.height,
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn edge_verticals_never_cross_nodes() {
+        // The coordinate passes (overlap repair, tightening, compaction)
+        // move real nodes; dummy waypoints must be realigned and nudged so
+        // no edge's vertical segment runs through node text. Crossing a
+        // subgraph border is acceptable; crossing a node never is.
+        assert_no_edge_crosses_nodes(&tier3_like_graph().compute_layout());
+        assert_no_edge_crosses_nodes(&tier5_like_graph().compute_layout());
+    }
+
+    #[test]
+    fn clusters_compact_after_separation() {
+        // compact_clusters pulls root clusters back together after the
+        // sibling-overlap shifts. Without it this layout leaves wide empty
+        // gulfs between boxes and the canvas exceeds 450 columns.
+        let g = tier3_like_graph();
+        let ir = g.compute_layout();
+        assert!(
+            ir.width() <= 420,
+            "canvas width {} suggests inter-cluster compaction regressed",
+            ir.width(),
+        );
     }
 
     #[test]


### PR DESCRIPTION
Four layout fixes for graphs with subgraphs, applied to both layout paths (heap and no-alloc CSR):

- **Cluster-width feedback:**  a cluster's border is a global x-envelope (member extent + padding + label width), but nodes on narrower levels only reserved per-level space, so external nodes could render inside a box. Unaffiliated nodes are now pushed clear of each projected envelope, the canvas covers label-widened borders instead of clipping them, and a label's contribution to box width is capped at 40 chars.

- **Per-level tightening:** sibling-overlap repair shifts whole clusters right, leaving nodes stranded far from their parents. A bounded pass pulls each node toward the median of its connected neighbors, clamped to its cluster's extent so no box can grow.

- **Inter-cluster compaction:** nothing previously pulled separated clusters back together, leaving wide empty gulfs crossed by long edge lines. Root clusters now compact leftward as rigid bodies against a per-level frontier (shift-left only). Canvas width drops up to 24% on the stress tiers (tier 5: 1284 -> 965 cols).

- **Node-safe edge routing:** compaction exposed stale dummy waypoints: edges drew straight through relocated nodes. Waypoints now shift with their endpoints and a final pass nudges any waypoint out of node spans. An edge that must cross something crosses a subgraph border (rendered as a junction), never node text.

Each fix has a regression test that fails with the fix reverted, including box-overlap, parent-alignment, canvas-width, and edge-crossing invariants (191 tests total, clippy clean, `no_std`/arena builds pass).