### PR TITLE
Add rank direction to LayoutConfig and IR.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - **Inter-cluster compaction**: root clusters and loose nodes are pulled back together after overlap separation, removing the empty gulfs between boxes (up to −24% canvas width on the stress tiers). Both layout paths.
 - **Edges never cross node text**: dummy waypoints are realigned when compaction moves their endpoints and nudged out of node spans; an edge that must cross something crosses a subgraph border (rendered as a junction), never a node. Both layout paths.
 
+### Added
+- **Rank direction (`Direction`) — IR groundwork**: `graph.set_direction(...)` / `LayoutConfig.direction` record the rank direction on the layout IR; parses from `"TB"`/`"TD"`/`"BT"`/`"LR"`/`"RL"`. For `BottomUp`, the heap layout path emits physical (flipped) coordinates. The built-in renderers currently paint `TopDown` layouts only.
+
 ### Internal
 - Rendered-output tests (`tests/layout_output.rs`): spacing config is now verified against the text a user sees, in both backends, plus a golden snapshot of the hero example (`cargo run --example hero` to regenerate).
 - Shared cluster-geometry constants moved to `algorithms/sugiyama/geometry.rs` — previously duplicated across the heap and CSR backends, where they could silently drift.

--- a/src/algorithms/sugiyama/arena_csr.rs
+++ b/src/algorithms/sugiyama/arena_csr.rs
@@ -897,7 +897,9 @@ pub fn compute_layout_arena_csr<'b>(
         }
     }
 
-    Ok(builder.build())
+    let mut ir = builder.build();
+    ir.set_direction(config.direction);
+    Ok(ir)
 }
 
 // Helpers for CSR layout (parallel implementation for CsrGraph)

--- a/src/algorithms/sugiyama/config.rs
+++ b/src/algorithms/sugiyama/config.rs
@@ -22,7 +22,7 @@
 //! ```
 
 use super::crossing::{CrossingReducer, FAST, QUALITY, STANDARD};
-use crate::graph::RenderMode;
+use crate::graph::{Direction, RenderMode};
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
@@ -157,6 +157,13 @@ pub struct LayoutConfig<'a> {
     /// Rendering mode (Auto, Vertical, Horizontal).
     pub render_mode: RenderMode,
 
+    /// Rank direction (default: [`Direction::TopDown`]).
+    ///
+    /// Recorded on the layout IR; for `BottomUp` the heap layout path
+    /// flips its result into physical coordinates. The built-in
+    /// renderers currently paint `TopDown` layouts only.
+    pub direction: Direction,
+
     /// Include dummy (virtual) nodes in the output IR.
     pub include_dummy_nodes: bool,
 
@@ -178,6 +185,7 @@ impl<'a> LayoutConfig<'a> {
             node_spacing: 3,
             level_spacing: 0,
             render_mode: RenderMode::Auto,
+            direction: Direction::TopDown,
             include_dummy_nodes: false,
             skip_validation: false,
         }
@@ -196,6 +204,7 @@ impl<'a> LayoutConfig<'a> {
             node_spacing: 3,
             level_spacing: 0,
             render_mode: RenderMode::Auto,
+            direction: Direction::TopDown,
             include_dummy_nodes: false,
             skip_validation: false,
         }
@@ -214,6 +223,7 @@ impl<'a> LayoutConfig<'a> {
             node_spacing: 3,
             level_spacing: 0,
             render_mode: RenderMode::Auto,
+            direction: Direction::TopDown,
             include_dummy_nodes: false,
             skip_validation: false,
         }
@@ -357,6 +367,7 @@ impl<'a> From<&'a SugiyamaConfig> for LayoutConfig<'a> {
             node_spacing: 3,
             level_spacing: 0,
             render_mode: sc.render_mode,
+            direction: Direction::TopDown,
             include_dummy_nodes: false,
             skip_validation: false,
         }

--- a/src/algorithms/sugiyama/heap.rs
+++ b/src/algorithms/sugiyama/heap.rs
@@ -797,8 +797,14 @@ pub(crate) fn compute_layout_cfg<'a>(dag: &Graph<'a>, config: &LayoutConfig<'_>)
         }
     }
     builder.set_dimensions(canvas_width, total_height);
+    builder.set_direction(config.direction);
 
-    builder.build()
+    let mut ir = builder.build();
+    if config.direction == crate::graph::Direction::BottomUp {
+        // Physical-space contract: IR coordinates match rendered cells.
+        ir.flip_vertical();
+    }
+    ir
 }
 
 // ── Crossing reduction ───────────────────────────────────────────────────

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -41,6 +41,58 @@ pub enum RenderMode {
     Auto,
 }
 
+/// Rank direction — the axis levels flow along.
+///
+/// Recorded on the layout IR; IR coordinates are physical (they match
+/// rendered cells). For `BottomUp`, the heap layout path flips its
+/// result into physical coordinates.
+///
+/// Parses from the conventional short forms (case-insensitive):
+/// `"TB"`/`"TD"`, `"BT"`, `"LR"`, `"RL"`.
+///
+/// The built-in renderers currently paint `TopDown` layouts only;
+/// rendering an IR with any other direction is unspecified.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Direction {
+    /// Levels flow top → bottom (default; edges point down).
+    #[default]
+    TopDown,
+    /// Levels flow bottom → top (edges point up).
+    BottomUp,
+    /// Levels flow left → right (edges point right).
+    LeftRight,
+    /// Levels flow right → left (edges point left).
+    RightLeft,
+}
+
+/// Error returned when parsing a [`Direction`] from an unknown string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseDirectionError;
+
+impl core::fmt::Display for ParseDirectionError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("unknown direction (expected TB/TD, BT, LR, or RL)")
+    }
+}
+
+impl core::str::FromStr for Direction {
+    type Err = ParseDirectionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.eq_ignore_ascii_case("TB") || s.eq_ignore_ascii_case("TD") {
+            Ok(Direction::TopDown)
+        } else if s.eq_ignore_ascii_case("BT") {
+            Ok(Direction::BottomUp)
+        } else if s.eq_ignore_ascii_case("LR") {
+            Ok(Direction::LeftRight)
+        } else if s.eq_ignore_ascii_case("RL") {
+            Ok(Direction::RightLeft)
+        } else {
+            Err(ParseDirectionError)
+        }
+    }
+}
+
 // Everything below requires the `alloc` feature (Vec, String, HashMap).
 #[cfg(feature = "alloc")]
 use alloc::{string::String, vec, vec::Vec};
@@ -124,6 +176,7 @@ pub struct Graph<'a> {
     pub(crate) nodes: Vec<(usize, &'a str)>,
     pub(crate) edges: Vec<(usize, usize, Option<&'a str>)>,
     pub(crate) render_mode: RenderMode,
+    pub(crate) direction: Direction,
     pub(crate) auto_created: HashSet<usize>, // Track auto-created nodes for visual distinction (O(1) lookups)
     pub(crate) id_to_index: HashMap<usize, usize>, // Cache id→index mapping (O(1) lookups)
     pub(crate) node_widths: Vec<usize>,      // Cached formatted widths
@@ -171,6 +224,7 @@ impl<'a> Graph<'a> {
             nodes: nodes.to_vec(),
             edges: Vec::new(),
             render_mode: RenderMode::default(),
+            direction: Direction::default(),
             auto_created: HashSet::new(),
             id_to_index: HashMap::new(),
             node_widths: Vec::new(),
@@ -223,6 +277,7 @@ impl<'a> Graph<'a> {
             nodes: nodes.to_vec(),
             edges: Vec::new(),
             render_mode: RenderMode::default(),
+            direction: Direction::default(),
             auto_created: HashSet::new(),
             id_to_index: HashMap::new(),
             node_widths: Vec::new(),
@@ -267,6 +322,28 @@ impl<'a> Graph<'a> {
     /// ```
     pub fn set_render_mode(&mut self, mode: RenderMode) {
         self.render_mode = mode;
+    }
+
+    /// Set the rank direction (see [`Direction`]).
+    ///
+    /// Applies when computing the layout via [`render`](Self::render) or
+    /// [`compute_layout`](Self::compute_layout). When you build a
+    /// [`LayoutConfig`] yourself and call
+    /// [`compute_layout_with_config`](Self::compute_layout_with_config),
+    /// the config's `direction` wins.
+    ///
+    /// The built-in renderers currently paint `TopDown` layouts only.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ascii_dag::graph::{Direction, Graph};
+    ///
+    /// let mut dag = Graph::new();
+    /// dag.set_direction(Direction::BottomUp);
+    /// ```
+    pub fn set_direction(&mut self, direction: Direction) {
+        self.direction = direction;
     }
 
     /// Set the full Sugiyama pipeline configuration.
@@ -362,6 +439,12 @@ impl<'a> Graph<'a> {
     /// ```
     pub fn with_render_mode(mut self, mode: RenderMode) -> Self {
         self.render_mode = mode;
+        self
+    }
+
+    /// Builder method: set the rank direction (chainable).
+    pub fn with_direction(mut self, direction: Direction) -> Self {
+        self.direction = direction;
         self
     }
 
@@ -769,7 +852,8 @@ impl<'a> Graph<'a> {
     /// }
     /// ```
     pub fn compute_layout(&self) -> crate::ir::LayoutIR<'a> {
-        let config: LayoutConfig<'_> = LayoutConfig::from(&self.sugiyama_config);
+        let mut config: LayoutConfig<'_> = LayoutConfig::from(&self.sugiyama_config);
+        config.direction = self.direction;
         crate::algorithms::sugiyama::heap::compute_layout_cfg(self, &config)
     }
 

--- a/src/ir/arena.rs
+++ b/src/ir/arena.rs
@@ -191,6 +191,8 @@ pub struct LayoutIRArena<'a> {
     level_offsets: &'a [usize],
     /// Node indices organized by level
     level_data: &'a [usize],
+    /// Rank direction the layout was computed for (applied at render time).
+    direction: crate::graph::Direction,
 }
 
 impl<'a> LayoutIRArena<'a> {
@@ -219,7 +221,19 @@ impl<'a> LayoutIRArena<'a> {
             level_count,
             level_offsets,
             level_data,
+            direction: crate::graph::Direction::TopDown,
         }
+    }
+
+    /// Set the rank direction the layout was computed for.
+    pub(crate) fn set_direction(&mut self, direction: crate::graph::Direction) {
+        self.direction = direction;
+    }
+
+    /// Rank direction the layout was computed for.
+    #[inline]
+    pub fn direction(&self) -> crate::graph::Direction {
+        self.direction
     }
 
     /// Get the total width of the layout in character cells.

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -251,6 +251,8 @@ pub struct LayoutIR<'a> {
     pub(crate) levels: Vec<Vec<usize>>,
     /// O(1) lookup from node ID to index in nodes vec
     pub(crate) id_to_index: HashMap<usize, usize>,
+    /// Rank direction the layout was computed for.
+    pub(crate) direction: crate::graph::Direction,
     /// Spatial index for fast scanline rendering (built lazily on first access)
     y_index: OnceCell<Vec<LineOccupancy>>,
 }
@@ -267,6 +269,53 @@ impl<'a> LayoutIR<'a> {
     #[inline]
     pub fn height(&self) -> usize {
         self.height
+    }
+
+    /// Rank direction the layout was computed for.
+    ///
+    /// IR coordinates are physical — for `Direction::BottomUp` they are
+    /// already flipped so they match rendered cells.
+    #[inline]
+    pub fn direction(&self) -> crate::graph::Direction {
+        self.direction
+    }
+
+    /// Vertically mirror every coordinate in place (involutive).
+    ///
+    /// Applied once at the end of layout for `Direction::BottomUp` to turn
+    /// the top-down logical result into physical coordinates.
+    pub(crate) fn flip_vertical(&mut self) {
+        let h = self.height;
+        let flip_row = |y: usize| h.saturating_sub(1).saturating_sub(y);
+        for node in &mut self.nodes {
+            node.y = h.saturating_sub(node.y + node.height);
+            node.center_y = flip_row(node.center_y);
+        }
+        for edge in &mut self.edges {
+            edge.from_y = flip_row(edge.from_y);
+            edge.to_y = flip_row(edge.to_y);
+            if let Some((_, ly)) = &mut edge.label_position {
+                *ly = flip_row(*ly);
+            }
+            match &mut edge.path {
+                EdgePath::Corner { horizontal_y } => *horizontal_y = flip_row(*horizontal_y),
+                EdgePath::MultiSegment { waypoints, .. } => {
+                    for (_, wy) in waypoints.iter_mut() {
+                        *wy = flip_row(*wy);
+                    }
+                }
+                EdgePath::SideChannel { start_y, end_y, .. } => {
+                    let (s, e) = (flip_row(*end_y), flip_row(*start_y));
+                    *start_y = s;
+                    *end_y = e;
+                }
+                _ => {}
+            }
+        }
+        for sg in &mut self.subgraphs {
+            sg.y = h.saturating_sub(sg.y + sg.height);
+        }
+        self.y_index = OnceCell::new();
     }
 
     /// Get the number of levels (depth) in the graph.
@@ -486,6 +535,7 @@ pub struct LayoutIRBuilder<'a> {
     height: usize,
     level_count: usize,
     levels: Vec<Vec<usize>>,
+    direction: crate::graph::Direction,
 }
 
 #[cfg(feature = "alloc")]
@@ -530,6 +580,11 @@ impl<'a> LayoutIRBuilder<'a> {
         self.height = height;
     }
 
+    /// Set the rank direction the layout was computed for.
+    pub fn set_direction(&mut self, direction: crate::graph::Direction) {
+        self.direction = direction;
+    }
+
     /// Build the final LayoutIR.
     pub fn build(self) -> LayoutIR<'a> {
         // Build id-to-index map for O(1) lookups
@@ -549,6 +604,7 @@ impl<'a> LayoutIRBuilder<'a> {
             level_count: self.level_count,
             levels: self.levels,
             id_to_index,
+            direction: self.direction,
             y_index: OnceCell::new(),
         }
     }

--- a/tests/layout_output.rs
+++ b/tests/layout_output.rs
@@ -176,3 +176,126 @@ fn hero_example_matches_golden() {
 }
 
 include!("../examples/shared/hero_graph.rs");
+
+// ── Direction ────────────────────────────────────────────────────────────
+
+mod direction {
+    use super::*;
+    use ascii_dag::graph::Direction;
+
+    #[test]
+    fn parses_conventional_short_forms() {
+        for (s, want) in [
+            ("TB", Direction::TopDown),
+            ("TD", Direction::TopDown),
+            ("tb", Direction::TopDown),
+            ("BT", Direction::BottomUp),
+            ("bt", Direction::BottomUp),
+            ("LR", Direction::LeftRight),
+            ("RL", Direction::RightLeft),
+        ] {
+            assert_eq!(s.parse::<Direction>().unwrap(), want, "parsing {s:?}");
+        }
+        assert!("NE".parse::<Direction>().is_err());
+        assert!("".parse::<Direction>().is_err());
+    }
+
+    fn stage_graph() -> Graph<'static> {
+        let mut g = Graph::new();
+        g.add_node(1, "Start");
+        g.add_node(2, "Middle");
+        g.add_node(3, "End");
+        g.add_edge(1, 2, Some("go"));
+        g.add_edge(2, 3, None);
+        let sg = g.add_subgraph("Stage");
+        g.put_nodes(&[2]).inside(sg).unwrap();
+        g
+    }
+
+    // NOTE: BottomUp assertions are IR-level only. The built-in renderers
+    // paint TopDown layouts exclusively until direction-aware rendering
+    // lands with the renderer rewrite — no test may render a BT IR.
+
+    #[test]
+    fn bottom_up_ir_records_direction() {
+        let mut g = stage_graph();
+        g.set_direction(Direction::BottomUp);
+        let ir = g.compute_layout();
+        assert_eq!(ir.direction(), Direction::BottomUp);
+        let td = stage_graph().compute_layout();
+        assert_eq!(td.direction(), Direction::TopDown);
+    }
+
+    #[test]
+    fn bottom_up_ir_puts_sources_at_bottom() {
+        // Physical coordinates: under BT the source sits on larger rows
+        // than the target.
+        let mut g = stage_graph();
+        g.set_direction(Direction::BottomUp);
+        let ir = g.compute_layout();
+        let start = ir.node_by_id(1).expect("Start in IR");
+        let end = ir.node_by_id(3).expect("End in IR");
+        assert!(
+            start.y > end.y,
+            "BottomUp: source row {} must be below target row {}",
+            start.y,
+            end.y,
+        );
+    }
+
+    #[test]
+    fn bottom_up_ir_is_exact_vertical_flip_of_top_down() {
+        // The physical BT IR must be the exact mirror of the TD IR:
+        // same dimensions, every y flipped, every x untouched.
+        let td = stage_graph().compute_layout();
+        let mut g = stage_graph();
+        g.set_direction(Direction::BottomUp);
+        let bt = g.compute_layout();
+
+        assert_eq!(bt.width(), td.width());
+        assert_eq!(bt.height(), td.height());
+        assert_eq!(bt.level_count(), td.level_count());
+
+        let h = td.height();
+        let flip_row = |y: usize| h - 1 - y;
+
+        for td_node in td.nodes() {
+            let bt_node = bt.node_by_id(td_node.id).expect("node in BT IR");
+            assert_eq!(bt_node.x, td_node.x, "x untouched for '{}'", td_node.label);
+            assert_eq!(bt_node.width, td_node.width);
+            assert_eq!(bt_node.height, td_node.height);
+            assert_eq!(
+                bt_node.y,
+                h - (td_node.y + td_node.height),
+                "flipped y for '{}'",
+                td_node.label,
+            );
+            assert_eq!(bt_node.center_y, flip_row(td_node.center_y));
+        }
+
+        for (td_edge, bt_edge) in td.edges().iter().zip(bt.edges()) {
+            assert_eq!(bt_edge.from_x, td_edge.from_x);
+            assert_eq!(bt_edge.to_x, td_edge.to_x);
+            assert_eq!(bt_edge.from_y, flip_row(td_edge.from_y));
+            assert_eq!(bt_edge.to_y, flip_row(td_edge.to_y));
+        }
+
+        for (td_sg, bt_sg) in td.subgraphs().iter().zip(bt.subgraphs()) {
+            assert_eq!(bt_sg.x, td_sg.x);
+            assert_eq!(bt_sg.width, td_sg.width);
+            assert_eq!(bt_sg.height, td_sg.height);
+            assert_eq!(bt_sg.y, h - (td_sg.y + td_sg.height));
+        }
+    }
+
+    #[test]
+    fn top_down_output_unchanged_by_direction_plumbing() {
+        // Explicit TopDown must be byte-identical to the default.
+        let g = stage_graph();
+        let default_out = g.compute_layout().render_scanline();
+        let mut g2 = stage_graph();
+        g2.set_direction(Direction::TopDown);
+        let explicit_out = g2.compute_layout().render_scanline();
+        assert_eq!(default_out, explicit_out);
+    }
+}


### PR DESCRIPTION
Direction is now recorded on the layout IR so downstream consumers know the axis levels flow along. The heap path flips its result into physical coordinates for BottomUp; Arena mode honors it at render time. Parsed from
TB/TD/BT/LR/RL (case-insensitive).